### PR TITLE
chore: remove vault from config — .github has no secrets

### DIFF
--- a/holocron.config.json
+++ b/holocron.config.json
@@ -8,7 +8,6 @@
     }
   },
   "providers": {
-    "vault": ["doppler", { "project": "theholocron", "config": "dev" }],
     "source": "github"
   }
 }


### PR DESCRIPTION
Remove `vault` from `providers` — this repo has no secrets. Vault is now optional in holocron. `holocron setup --cwd .` runs 9 ok, 0 fail.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/.github/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->