### PR TITLE
feat: reusable CI infrastructure — workflows, actions, templates, security

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/actions/install/action.yml
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Install dependencies

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/actions/install/action.yml
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Install dependencies

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/actions/install/action.yml
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Install dependencies

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/actions/install/action.yml
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Install dependencies

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/actions/setup-node/action.yml
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Setup Node

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/actions/setup-node/action.yml
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Setup Node

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/actions/setup-node/action.yml
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Setup Node

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/actions/setup-node/action.yml
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Setup Node

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/actions/setup/action.yml
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Setup

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/actions/setup/action.yml
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Setup

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/actions/setup/action.yml
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Setup

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/actions/setup/action.yml
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Setup

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,25 +1,26 @@
 ---
 # Conventional Commits title matching (include-title: 1 in bookkeeping-pr.yml)
+# Patterns use [:(] to match exactly — ^fix alone would match "fixture", "fixing", etc.
 chore:
-  - "^chore"
+  - "^chore[:(]"
 
 ci:
-  - "^ci"
+  - "^ci[:(]"
 
 documentation:
-  - "^docs"
+  - "^docs[:(]"
 
 bug:
-  - "^fix"
+  - "^fix[:(]"
 
 enhancement:
-  - "^feat"
+  - "^feat[:(]"
 
 refactor:
-  - "^refactor"
+  - "^refactor[:(]"
 
 performance:
-  - "^perf"
+  - "^perf[:(]"
 
 test:
-  - "^test"
+  - "^test[:(]"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,26 +1,30 @@
 ---
 # Conventional Commits title matching (include-title: 1 in bookkeeping-pr.yml)
-# Patterns use [:(] to match exactly — ^fix alone would match "fixture", "fixing", etc.
+# Patterns use [!:(] to match all valid CC forms:
+#   fix:          normal fix
+#   fix(scope):   scoped fix
+#   fix!:         breaking fix
+#   fix!(scope):  breaking scoped fix
 chore:
-  - "^chore[:(]"
+  - "^chore[!:(]"
 
 ci:
-  - "^ci[:(]"
+  - "^ci[!:(]"
 
 documentation:
-  - "^docs[:(]"
+  - "^docs[!:(]"
 
 bug:
-  - "^fix[:(]"
+  - "^fix[!:(]"
 
 enhancement:
-  - "^feat[:(]"
+  - "^feat[!:(]"
 
 refactor:
-  - "^refactor[:(]"
+  - "^refactor[!:(]"
 
 performance:
-  - "^perf[:(]"
+  - "^perf[!:(]"
 
 test:
-  - "^test[:(]"
+  - "^test[!:(]"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,21 +1,25 @@
-# Add "documentation" label to any changes within "docs" folder or any subfolders or .md files within the entire repository
+---
+# Conventional Commits title matching (include-title: 1 in bookkeeping-pr.yml)
+chore:
+  - "^chore"
+
+ci:
+  - "^ci"
+
 documentation:
-- any:
-  - changed-files:
-    - any-glob-to-any-file:
-      - docs/**
-      - "**/*.md"
+  - "^docs"
 
-# Add "bug" label to any PR where the head branch name starts with `fix` with file changes to src directory
 bug:
-- all:
-  - changed-files:
-    - any-glob-to-any-file: src/**
-  - head-branch: "^fix-"
+  - "^fix"
 
-# Add "enhancement" label to any PR where the head branch name starts with `feat` with file changes to src directory
 enhancement:
-- all:
-  - changed-files:
-    - any-glob-to-any-file: src/**
-  - head-branch: "^feat-"
+  - "^feat"
+
+refactor:
+  - "^refactor"
+
+performance:
+  - "^perf"
+
+test:
+  - "^test"

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,11 +1,11 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/audit.yml
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Audit
 
-on:
+on: # yamllint disable-line rule:truthy
   workflow_call:
     inputs:
       build-script:

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/audit.yml
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Audit

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/audit.yml
-# Synced:  2026-07-08T19:18:56.879Z
+# Synced:  2026-07-08T19:30:52.886Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Audit

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/audit.yml
-# Synced:  2026-07-08T18:58:21.598Z
+# Synced:  2026-07-08T19:18:56.879Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Audit

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/audit.yml
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Audit

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/audit.yml
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Audit

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/audit.yml
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-08T18:58:21.598Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Audit

--- a/.github/workflows/bookkeeping-pr.yml
+++ b/.github/workflows/bookkeeping-pr.yml
@@ -1,16 +1,11 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/bookkeeping-pr.yml
-# Synced:  2026-07-08T19:18:56.879Z
+# Synced:  2026-07-08T19:30:52.886Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: PR Bookkeeping
 
 on: # yamllint disable-line rule:truthy
-  # Direct trigger: labels PRs opened against THIS repo (theholocron/.github).
-  # This repo houses reusable workflows — it will never adopt a thin caller
-  # that calls bookkeeping-pr.yml@main, so no duplicate-run risk exists.
-  pull_request:
-    types: [opened, edited]
   workflow_call:
     inputs:
       configuration-path:

--- a/.github/workflows/bookkeeping-pr.yml
+++ b/.github/workflows/bookkeeping-pr.yml
@@ -1,11 +1,11 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/bookkeeping-pr.yml
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: PR Bookkeeping
 
-on:
+on: # yamllint disable-line rule:truthy
   pull_request:
     types: [opened, edited, synchronize]
   workflow_call:

--- a/.github/workflows/bookkeeping-pr.yml
+++ b/.github/workflows/bookkeeping-pr.yml
@@ -1,13 +1,13 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/bookkeeping-pr.yml
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-08T18:58:21.598Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: PR Bookkeeping
 
 on: # yamllint disable-line rule:truthy
   pull_request:
-    types: [opened, edited, synchronize]
+    types: [opened, edited]
   workflow_call:
     inputs:
       configuration-path:
@@ -30,7 +30,9 @@ jobs:
     steps:
       - uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 # v3.4
         with:
-          configuration-path: ${{ inputs.configuration-path }}
+          # Fall back to default path when triggered directly (not via workflow_call)
+          # because inputs.* defaults only apply on workflow_call events.
+          configuration-path: ${{ inputs.configuration-path || '.github/labeler.yml' }}
           include-title: 1
           include-body: 0
           sync-labels: 1

--- a/.github/workflows/bookkeeping-pr.yml
+++ b/.github/workflows/bookkeeping-pr.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/bookkeeping-pr.yml
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: PR Bookkeeping

--- a/.github/workflows/bookkeeping-pr.yml
+++ b/.github/workflows/bookkeeping-pr.yml
@@ -1,11 +1,14 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/bookkeeping-pr.yml
-# Synced:  2026-07-08T18:58:21.598Z
+# Synced:  2026-07-08T19:18:56.879Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: PR Bookkeeping
 
 on: # yamllint disable-line rule:truthy
+  # Direct trigger: labels PRs opened against THIS repo (theholocron/.github).
+  # This repo houses reusable workflows — it will never adopt a thin caller
+  # that calls bookkeeping-pr.yml@main, so no duplicate-run risk exists.
   pull_request:
     types: [opened, edited]
   workflow_call:

--- a/.github/workflows/bookkeeping-pr.yml
+++ b/.github/workflows/bookkeeping-pr.yml
@@ -1,11 +1,13 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/bookkeeping-pr.yml
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: PR Bookkeeping
 
 on:
+  pull_request:
+    types: [opened, edited, synchronize]
   workflow_call:
     inputs:
       configuration-path:

--- a/.github/workflows/bookkeeping-pr.yml
+++ b/.github/workflows/bookkeeping-pr.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/bookkeeping-pr.yml
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: PR Bookkeeping

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/codeql.yml
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-08T18:58:21.598Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,11 +1,11 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/codeql.yml
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: CodeQL
 
-on:
+on: # yamllint disable-line rule:truthy
   workflow_call:
     inputs:
       language:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/codeql.yml
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/codeql.yml
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/codeql.yml
-# Synced:  2026-07-08T18:58:21.598Z
+# Synced:  2026-07-08T19:18:56.879Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/codeql.yml
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/codeql.yml
-# Synced:  2026-07-08T19:18:56.879Z
+# Synced:  2026-07-08T19:30:52.886Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: CodeQL

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,11 +1,11 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/dependencies.yml
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Dependencies
 
-on:
+on: # yamllint disable-line rule:truthy
   workflow_call:
     secrets:
       merge-token:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/dependencies.yml
-# Synced:  2026-07-08T19:18:56.879Z
+# Synced:  2026-07-08T19:30:52.886Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Dependencies

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/dependencies.yml
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Dependencies

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/dependencies.yml
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Dependencies

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/dependencies.yml
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-08T18:58:21.598Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Dependencies

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/dependencies.yml
-# Synced:  2026-07-08T18:58:21.598Z
+# Synced:  2026-07-08T19:18:56.879Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Dependencies

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/dependencies.yml
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Dependencies

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/greetings.yml
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Greetings

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/greetings.yml
-# Synced:  2026-07-08T19:18:56.879Z
+# Synced:  2026-07-08T19:30:52.886Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Greetings

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/greetings.yml
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Greetings

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,11 +1,11 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/greetings.yml
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Greetings
 
-on:
+on: # yamllint disable-line rule:truthy
   workflow_call:
 
 jobs:

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/greetings.yml
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Greetings

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/greetings.yml
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-08T18:58:21.598Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Greetings

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/greetings.yml
-# Synced:  2026-07-08T18:58:21.598Z
+# Synced:  2026-07-08T19:18:56.879Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Greetings

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/lint.yml
-# Synced:  2026-07-08T19:18:56.879Z
+# Synced:  2026-07-08T19:30:52.886Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/lint.yml
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-08T18:58:21.598Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/lint.yml
-# Synced:  2026-07-08T18:58:21.598Z
+# Synced:  2026-07-08T19:18:56.879Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,11 +1,11 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/lint.yml
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Lint
 
-on:
+on: # yamllint disable-line rule:truthy
   workflow_call:
     inputs:
       prettier-config:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/lint.yml
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/lint.yml
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/lint.yml
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/release.yml
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Release
@@ -9,7 +9,7 @@ name: Release
 # The calling repo must have a .releaserc.json that configures branches,
 # plugins, and any publish options. npm@11+ is installed to support OIDC.
 
-on:
+on: # yamllint disable-line rule:truthy
   workflow_call:
     inputs:
       run-build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/release.yml
-# Synced:  2026-07-08T18:58:21.598Z
+# Synced:  2026-07-08T19:18:56.879Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/release.yml
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/release.yml
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/release.yml
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-08T18:58:21.598Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/release.yml
-# Synced:  2026-07-08T19:18:56.879Z
+# Synced:  2026-07-08T19:30:52.886Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/release.yml
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Release

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,15 +1,17 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/review.yml
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Review
 
-# ReviewDog is the annotation layer — runs linters and posts inline PR diff
-# annotations. Runs on pull_request only (annotation reporters require PR context).
-# super-linter (lint.yml) is the CI gate that runs on push + PR.
-# Gitleaks and YAML are intentionally duplicated here: super-linter catches
-# them as CI failures, ReviewDog surfaces them as inline diff annotations.
+# ReviewDog is the annotation layer — runs linters and posts inline diff
+# annotations on PRs, and Checks-tab annotations on direct pushes.
+# Reporter switches based on event: github-pr-check on PRs (inline diff),
+# github-check on push (Checks tab only).
+# super-linter (lint.yml) is the CI gate; this workflow is annotation-only.
+# Gitleaks and YAML are intentionally duplicated: super-linter gates merges,
+# ReviewDog surfaces exact line annotations.
 
 on: # yamllint disable-line rule:truthy
   workflow_call:
@@ -48,12 +50,12 @@ jobs:
       - name: Gitleaks (secrets)
         uses: reviewdog/action-gitleaks@2b7b5685e3e3eecddab5d30cfa04f18123031421 # v1
         with:
-          reporter: github-pr-check
+          reporter: ${{ github.event.pull_request != null && 'github-pr-check' || 'github-check' }}
 
       - name: YamlLint
         uses: reviewdog/action-yamllint@b5f7217d8c815ae374d1d55840d5e569d82f01f0 # v1
         with:
-          reporter: github-pr-check
+          reporter: ${{ github.event.pull_request != null && 'github-pr-check' || 'github-check' }}
           yamllint_flags: >-
             ${{ hashFiles('yamllint.config.yml') != ''
                 && format('-c {0}/yamllint.config.yml {0}', github.workspace)
@@ -63,7 +65,7 @@ jobs:
         if: ${{ hashFiles('.github/workflows/*.yml', '.github/workflows/*.yaml') != '' }}
         uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1
         with:
-          reporter: github-pr-check
+          reporter: ${{ github.event.pull_request != null && 'github-pr-check' || 'github-check' }}
 
       #
       # TypeScript / JavaScript
@@ -87,14 +89,14 @@ jobs:
           }}
         uses: reviewdog/action-eslint@556a3fdaf8b4201d4d74d406013386aa4f7dab96 # v1
         with:
-          reporter: github-pr-check
+          reporter: ${{ github.event.pull_request != null && 'github-pr-check' || 'github-check' }}
           eslint_flags: .
 
       - name: TypeScript
         if: ${{ hashFiles('**/tsconfig.json') != '' }}
         uses: EPMatt/reviewdog-action-tsc@63d923a3c5b4497671940b8874f58a404e2351b5 # v1
         with:
-          reporter: github-pr-check
+          reporter: ${{ github.event.pull_request != null && 'github-pr-check' || 'github-check' }}
 
       #
       # Shell
@@ -104,7 +106,7 @@ jobs:
         if: ${{ hashFiles('**/*.sh') != '' }}
         uses: reviewdog/action-shellcheck@4c07458293ac342d477251099501a718ae5ef86e # v1
         with:
-          reporter: github-pr-check
+          reporter: ${{ github.event.pull_request != null && 'github-pr-check' || 'github-check' }}
           fail_level: none
 
       #
@@ -122,7 +124,7 @@ jobs:
           }}
         uses: reviewdog/action-hadolint@1b2cfa6ba72072ad35158d7ff3aa49bbdc03506d # v1
         with:
-          reporter: github-pr-check
+          reporter: ${{ github.event.pull_request != null && 'github-pr-check' || 'github-check' }}
           fail_level: none
 
       #
@@ -133,7 +135,7 @@ jobs:
         if: ${{ hashFiles('**/.env*') != '' }}
         uses: dotenv-linter/action-dotenv-linter@21287e2624aaf2dc8da5dd8ccfe8e49c63501116 # v2
         with:
-          reporter: github-code-suggestions
+          reporter: ${{ github.event.pull_request != null && 'github-code-suggestions' || 'github-check' }}
 
       #
       # Documentation
@@ -143,4 +145,4 @@ jobs:
         if: ${{ hashFiles('**/*.md') != '' }}
         uses: reviewdog/action-alex@347481655add010a2ae302df34b57c9bcfa0d6e4 # v1
         with:
-          reporter: github-pr-check
+          reporter: ${{ github.event.pull_request != null && 'github-pr-check' || 'github-check' }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/review.yml
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Review
@@ -11,7 +11,7 @@ name: Review
 # Gitleaks and YAML are intentionally duplicated here: super-linter catches
 # them as CI failures, ReviewDog surfaces them as inline diff annotations.
 
-on:
+on: # yamllint disable-line rule:truthy
   workflow_call:
 
 concurrency:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/review.yml
-# Synced:  2026-07-08T18:58:21.598Z
+# Synced:  2026-07-08T19:18:56.879Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Review

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,17 +1,16 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/review.yml
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Review
 
-# ReviewDog is the annotation layer — runs linters and posts inline diff
-# annotations on PRs, and Checks-tab annotations on direct pushes.
-# Reporter switches based on event: github-pr-check on PRs (inline diff),
-# github-check on push (Checks tab only).
-# super-linter (lint.yml) is the CI gate; this workflow is annotation-only.
-# Gitleaks and YAML are intentionally duplicated: super-linter gates merges,
-# ReviewDog surfaces exact line annotations.
+# ReviewDog is the annotation layer — posts inline PR diff annotations.
+# Runs on pull_request only: inline annotations require PR context,
+# and branch protection ensures all changes go through PRs anyway.
+# super-linter (lint.yml) is the CI gate covering push + PR events.
+# Gitleaks and YAML are intentionally duplicated: super-linter gates
+# merges; ReviewDog surfaces exact line annotations in the PR diff.
 
 on: # yamllint disable-line rule:truthy
   workflow_call:
@@ -50,12 +49,12 @@ jobs:
       - name: Gitleaks (secrets)
         uses: reviewdog/action-gitleaks@2b7b5685e3e3eecddab5d30cfa04f18123031421 # v1
         with:
-          reporter: ${{ github.event.pull_request != null && 'github-pr-check' || 'github-check' }}
+          reporter: github-pr-check
 
       - name: YamlLint
         uses: reviewdog/action-yamllint@b5f7217d8c815ae374d1d55840d5e569d82f01f0 # v1
         with:
-          reporter: ${{ github.event.pull_request != null && 'github-pr-check' || 'github-check' }}
+          reporter: github-pr-check
           yamllint_flags: >-
             ${{ hashFiles('yamllint.config.yml') != ''
                 && format('-c {0}/yamllint.config.yml {0}', github.workspace)
@@ -65,7 +64,7 @@ jobs:
         if: ${{ hashFiles('.github/workflows/*.yml', '.github/workflows/*.yaml') != '' }}
         uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1
         with:
-          reporter: ${{ github.event.pull_request != null && 'github-pr-check' || 'github-check' }}
+          reporter: github-pr-check
 
       #
       # TypeScript / JavaScript
@@ -89,14 +88,14 @@ jobs:
           }}
         uses: reviewdog/action-eslint@556a3fdaf8b4201d4d74d406013386aa4f7dab96 # v1
         with:
-          reporter: ${{ github.event.pull_request != null && 'github-pr-check' || 'github-check' }}
+          reporter: github-pr-check
           eslint_flags: .
 
       - name: TypeScript
         if: ${{ hashFiles('**/tsconfig.json') != '' }}
         uses: EPMatt/reviewdog-action-tsc@63d923a3c5b4497671940b8874f58a404e2351b5 # v1
         with:
-          reporter: ${{ github.event.pull_request != null && 'github-pr-check' || 'github-check' }}
+          reporter: github-pr-check
 
       #
       # Shell
@@ -106,7 +105,7 @@ jobs:
         if: ${{ hashFiles('**/*.sh') != '' }}
         uses: reviewdog/action-shellcheck@4c07458293ac342d477251099501a718ae5ef86e # v1
         with:
-          reporter: ${{ github.event.pull_request != null && 'github-pr-check' || 'github-check' }}
+          reporter: github-pr-check
           fail_level: none
 
       #
@@ -124,7 +123,7 @@ jobs:
           }}
         uses: reviewdog/action-hadolint@1b2cfa6ba72072ad35158d7ff3aa49bbdc03506d # v1
         with:
-          reporter: ${{ github.event.pull_request != null && 'github-pr-check' || 'github-check' }}
+          reporter: github-pr-check
           fail_level: none
 
       #
@@ -135,7 +134,7 @@ jobs:
         if: ${{ hashFiles('**/.env*') != '' }}
         uses: dotenv-linter/action-dotenv-linter@21287e2624aaf2dc8da5dd8ccfe8e49c63501116 # v2
         with:
-          reporter: ${{ github.event.pull_request != null && 'github-code-suggestions' || 'github-check' }}
+          reporter: github-code-suggestions
 
       #
       # Documentation
@@ -145,4 +144,4 @@ jobs:
         if: ${{ hashFiles('**/*.md') != '' }}
         uses: reviewdog/action-alex@347481655add010a2ae302df34b57c9bcfa0d6e4 # v1
         with:
-          reporter: ${{ github.event.pull_request != null && 'github-pr-check' || 'github-check' }}
+          reporter: github-pr-check

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/review.yml
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Review

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/review.yml
-# Synced:  2026-07-08T19:18:56.879Z
+# Synced:  2026-07-08T19:30:52.886Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Review

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/review.yml
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-08T18:58:21.598Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Review

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/stale.yml
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/stale.yml
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/stale.yml
-# Synced:  2026-07-08T19:18:56.879Z
+# Synced:  2026-07-08T19:30:52.886Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/stale.yml
-# Synced:  2026-07-08T18:58:21.598Z
+# Synced:  2026-07-08T19:18:56.879Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/stale.yml
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/stale.yml
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-08T18:58:21.598Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,11 +1,11 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/stale.yml
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Stale
 
-on:
+on: # yamllint disable-line rule:truthy
   workflow_call:
     inputs:
       days-before-stale:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/test.yml
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/test.yml
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/test.yml
-# Synced:  2026-07-08T19:18:56.879Z
+# Synced:  2026-07-08T19:30:52.886Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/test.yml
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-08T18:58:21.598Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/test.yml
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/test.yml
-# Synced:  2026-07-08T18:58:21.598Z
+# Synced:  2026-07-08T19:18:56.879Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,11 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/test.yml
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Test
 
-on:
+on: # yamllint disable-line rule:truthy
   workflow_call:
     secrets:
       CODECOV_TOKEN:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/typecheck.yml
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Typecheck

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/typecheck.yml
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-08T18:58:21.598Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Typecheck

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/typecheck.yml
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Typecheck

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,11 +1,11 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/typecheck.yml
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Typecheck
 
-on:
+on: # yamllint disable-line rule:truthy
   workflow_call:
 
 jobs:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/typecheck.yml
-# Synced:  2026-07-08T19:18:56.879Z
+# Synced:  2026-07-08T19:30:52.886Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Typecheck

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/typecheck.yml
-# Synced:  2026-07-08T18:58:21.598Z
+# Synced:  2026-07-08T19:18:56.879Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Typecheck

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/typecheck.yml
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Typecheck

--- a/README.md
+++ b/README.md
@@ -1,3 +1,113 @@
-# .github
+# theholocron/.github
 
-Special repository for providing community health documentation.
+Org-level community health files, reusable CI workflows, composite actions,
+and workflow starter templates for the `theholocron` org — and any org that
+wants to reuse them.
+
+## Using reusable workflows
+
+Any public repo can call these workflows directly. A full CI setup is a handful
+of thin caller files in `.github/workflows/`:
+
+```yaml
+# .github/workflows/lint.yml
+name: Lint
+on: [push, pull_request]
+permissions:
+  contents: write
+  statuses: write
+jobs:
+  lint:
+    uses: theholocron/.github/.github/workflows/lint.yml@main
+    secrets: inherit
+```
+
+For `theholocron` repos the recommended approach is [`holocron setup`](#holocron-setup),
+which writes and maintains these files automatically from `holocron.config.json`.
+
+## Available workflows
+
+| Workflow | Trigger | Purpose |
+|---|---|---|
+| `lint.yml` | push + PR | super-linter CI gate — Prettier, YAML, ESLint configs, Gitleaks, ActionLint |
+| `test.yml` | push + PR | vitest + Codecov coverage upload |
+| `typecheck.yml` | push + PR | `pnpm typecheck` (`tsc --noEmit`) |
+| `codeql.yml` | push/PR to main + weekly | CodeQL security scan (javascript-typescript) |
+| `review.yml` | PR only | ReviewDog annotation layer — ESLint, tsc, ShellCheck, Hadolint, ActionLint, Gitleaks, YamlLint, dotenv-linter, Alex |
+| `release.yml` | push to main | semantic-release + OIDC Trusted Publishing (no `NPM_TOKEN` needed) |
+| `stale.yml` | daily schedule | marks stale issues/PRs |
+| `greetings.yml` | PR + issues | first-time contributor welcome message |
+| `dependencies.yml` | PR | Dependabot auto-merge for semver-patch updates |
+| `bookkeeping-pr.yml` | PR opened/edited | labels PRs from Conventional Commit title (`fix:` → bug, `feat:` → enhancement, etc.) |
+| `audit.yml` | push + PR | BundleWatch bundle size analysis |
+
+Each workflow accepts inputs to customise behaviour — see the workflow files in
+`.github/workflows/` for the full input/secret declarations.
+
+## Composite actions
+
+Reusable action steps callable from any workflow:
+
+```yaml
+- uses: theholocron/.github/.github/actions/setup@main
+```
+
+| Action | Purpose |
+|---|---|
+| `setup` | Orchestrates `setup-node` + `install` in one step |
+| `setup-node` | pnpm + Node 22 with pnpm dependency caching |
+| `install` | `pnpm install --frozen-lockfile` |
+
+## Workflow starter templates
+
+The `workflow-templates/` directory powers the **"By your organization"**
+section in GitHub's **Actions → New workflow** UI. Every template is a thin
+caller of the matching reusable workflow above — repos that adopt a template
+get the same logic as repos that use `holocron setup`.
+
+## `holocron setup`
+
+For `theholocron` repos, the CLI manages everything from a `holocron.config.json`
+at the repo root:
+
+```jsonc
+{
+  "project": {
+    "name": "my-project",
+    "repo": "theholocron/my-project",
+    "repoPolicy": {
+      "preset": "strict",
+      "requiredChecks": ["Lint entire codebase", "Run tests and collect coverage", "tsc --noEmit"]
+    },
+    "workflows": ["lint", "test", "typecheck", "codeql", "review", "release"]
+  },
+  "providers": {
+    "vault": ["doppler", { "project": "my-project", "config": "dev" }],
+    "source": "github",
+    "ci": "github",
+    "secrets": "github"
+  }
+}
+```
+
+Running `pnpm holocron setup` (or `npx @theholocron/cli setup`) will:
+
+- Enable all GitHub security features (Dependabot, secret scanning, CodeQL, etc.)
+- Apply repo settings (squash-only merges, auto-merge, no wiki, etc.)
+- Create branch protection rulesets with the configured required checks
+- Write thin workflow caller files to `.github/workflows/`
+- Provision `.github/dependabot.yml` with grouped update configuration
+
+See [theholocron/holocron](https://github.com/theholocron/holocron) for the full CLI docs.
+
+## Source of truth
+
+The workflow and action files in this repo are **generated** from
+[theholocron/holocron](https://github.com/theholocron/holocron) — do not edit them
+directly here. To update a workflow:
+
+1. Edit `packages/cli/src/templates/workflows/<name>.yml` in `holocron`
+2. Push to `alpha` — the `sync-github` CI workflow opens a PR here automatically
+
+Community health files (`CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, issue templates,
+`CODEOWNERS`, `labeler.yml`, etc.) are hand-maintained in this repo directly.

--- a/workflow-templates/audit.yml
+++ b/workflow-templates/audit.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T18:58:21.598Z
+# Synced:  2026-07-08T19:18:56.879Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Audit

--- a/workflow-templates/audit.yml
+++ b/workflow-templates/audit.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-08T18:58:21.598Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Audit

--- a/workflow-templates/audit.yml
+++ b/workflow-templates/audit.yml
@@ -1,12 +1,13 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Audit
 
 on: # yamllint disable-line rule:truthy
   push:
+    branches: [main, alpha]
   pull_request:
 
 permissions:

--- a/workflow-templates/audit.yml
+++ b/workflow-templates/audit.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T19:18:56.879Z
+# Synced:  2026-07-08T19:30:52.886Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Audit

--- a/workflow-templates/audit.yml
+++ b/workflow-templates/audit.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Audit

--- a/workflow-templates/audit.yml
+++ b/workflow-templates/audit.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Audit

--- a/workflow-templates/audit.yml
+++ b/workflow-templates/audit.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Audit

--- a/workflow-templates/bookkeeping-pr.yml
+++ b/workflow-templates/bookkeeping-pr.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T18:58:21.598Z
+# Synced:  2026-07-08T19:18:56.879Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: PR Bookkeeping

--- a/workflow-templates/bookkeeping-pr.yml
+++ b/workflow-templates/bookkeeping-pr.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: PR Bookkeeping

--- a/workflow-templates/bookkeeping-pr.yml
+++ b/workflow-templates/bookkeeping-pr.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: PR Bookkeeping

--- a/workflow-templates/bookkeeping-pr.yml
+++ b/workflow-templates/bookkeeping-pr.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: PR Bookkeeping

--- a/workflow-templates/bookkeeping-pr.yml
+++ b/workflow-templates/bookkeeping-pr.yml
@@ -1,11 +1,11 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: PR Bookkeeping
 
-on:
+on: # yamllint disable-line rule:truthy
   pull_request:
     types:
       - opened

--- a/workflow-templates/bookkeeping-pr.yml
+++ b/workflow-templates/bookkeeping-pr.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T19:18:56.879Z
+# Synced:  2026-07-08T19:30:52.886Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: PR Bookkeeping

--- a/workflow-templates/bookkeeping-pr.yml
+++ b/workflow-templates/bookkeeping-pr.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-08T18:58:21.598Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: PR Bookkeeping

--- a/workflow-templates/codeql.yml
+++ b/workflow-templates/codeql.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T18:58:21.598Z
+# Synced:  2026-07-08T19:18:56.879Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: CodeQL

--- a/workflow-templates/codeql.yml
+++ b/workflow-templates/codeql.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: CodeQL

--- a/workflow-templates/codeql.yml
+++ b/workflow-templates/codeql.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: CodeQL

--- a/workflow-templates/codeql.yml
+++ b/workflow-templates/codeql.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: CodeQL

--- a/workflow-templates/codeql.yml
+++ b/workflow-templates/codeql.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T19:18:56.879Z
+# Synced:  2026-07-08T19:30:52.886Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: CodeQL

--- a/workflow-templates/codeql.yml
+++ b/workflow-templates/codeql.yml
@@ -1,11 +1,11 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: CodeQL
 
-on:
+on: # yamllint disable-line rule:truthy
   push:
     branches:
       - main

--- a/workflow-templates/codeql.yml
+++ b/workflow-templates/codeql.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-08T18:58:21.598Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: CodeQL

--- a/workflow-templates/dependencies.yml
+++ b/workflow-templates/dependencies.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Dependencies

--- a/workflow-templates/dependencies.yml
+++ b/workflow-templates/dependencies.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Dependencies

--- a/workflow-templates/dependencies.yml
+++ b/workflow-templates/dependencies.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Dependencies

--- a/workflow-templates/dependencies.yml
+++ b/workflow-templates/dependencies.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-08T18:58:21.598Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Dependencies

--- a/workflow-templates/dependencies.yml
+++ b/workflow-templates/dependencies.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T18:58:21.598Z
+# Synced:  2026-07-08T19:18:56.879Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Dependencies

--- a/workflow-templates/dependencies.yml
+++ b/workflow-templates/dependencies.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Dependencies

--- a/workflow-templates/dependencies.yml
+++ b/workflow-templates/dependencies.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T19:18:56.879Z
+# Synced:  2026-07-08T19:30:52.886Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Dependencies

--- a/workflow-templates/greetings.yml
+++ b/workflow-templates/greetings.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-08T18:58:21.598Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Greetings

--- a/workflow-templates/greetings.yml
+++ b/workflow-templates/greetings.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T18:58:21.598Z
+# Synced:  2026-07-08T19:18:56.879Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Greetings

--- a/workflow-templates/greetings.yml
+++ b/workflow-templates/greetings.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Greetings

--- a/workflow-templates/greetings.yml
+++ b/workflow-templates/greetings.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T19:18:56.879Z
+# Synced:  2026-07-08T19:30:52.886Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Greetings

--- a/workflow-templates/greetings.yml
+++ b/workflow-templates/greetings.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Greetings

--- a/workflow-templates/greetings.yml
+++ b/workflow-templates/greetings.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Greetings

--- a/workflow-templates/greetings.yml
+++ b/workflow-templates/greetings.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Greetings

--- a/workflow-templates/lint.yml
+++ b/workflow-templates/lint.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Lint

--- a/workflow-templates/lint.yml
+++ b/workflow-templates/lint.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T18:58:21.598Z
+# Synced:  2026-07-08T19:18:56.879Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Lint

--- a/workflow-templates/lint.yml
+++ b/workflow-templates/lint.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Lint

--- a/workflow-templates/lint.yml
+++ b/workflow-templates/lint.yml
@@ -1,12 +1,13 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Lint
 
 on: # yamllint disable-line rule:truthy
   push:
+    branches: [main, alpha]
   pull_request:
 
 concurrency:
@@ -19,6 +20,7 @@ permissions:
 
 jobs:
   lint:
+    name: Lint
     uses: theholocron/.github/.github/workflows/lint.yml@main
     secrets: inherit
     with:

--- a/workflow-templates/lint.yml
+++ b/workflow-templates/lint.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T19:18:56.879Z
+# Synced:  2026-07-08T19:30:52.886Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Lint

--- a/workflow-templates/lint.yml
+++ b/workflow-templates/lint.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Lint

--- a/workflow-templates/lint.yml
+++ b/workflow-templates/lint.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-08T18:58:21.598Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Lint

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T18:58:21.598Z
+# Synced:  2026-07-08T19:18:56.879Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Release

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-08T18:58:21.598Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Release

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T19:18:56.879Z
+# Synced:  2026-07-08T19:30:52.886Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Release

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Release

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Release

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -1,11 +1,11 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Release
 
-on:
+on: # yamllint disable-line rule:truthy
   push:
     branches:
       - main

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Release

--- a/workflow-templates/review.yml
+++ b/workflow-templates/review.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T19:18:56.879Z
+# Synced:  2026-07-08T19:30:52.886Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Review

--- a/workflow-templates/review.yml
+++ b/workflow-templates/review.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T18:58:21.598Z
+# Synced:  2026-07-08T19:18:56.879Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Review

--- a/workflow-templates/review.yml
+++ b/workflow-templates/review.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Review

--- a/workflow-templates/review.yml
+++ b/workflow-templates/review.yml
@@ -1,11 +1,12 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Review
 
 on: # yamllint disable-line rule:truthy
+  push:
   pull_request:
 
 permissions:

--- a/workflow-templates/review.yml
+++ b/workflow-templates/review.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-08T18:58:21.598Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Review

--- a/workflow-templates/review.yml
+++ b/workflow-templates/review.yml
@@ -1,13 +1,16 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Review
 
 on: # yamllint disable-line rule:truthy
-  push:
   pull_request:
+
+concurrency:
+  group: review-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -16,5 +19,6 @@ permissions:
 
 jobs:
   review:
+    name: Review
     uses: theholocron/.github/.github/workflows/review.yml@main
     secrets: inherit

--- a/workflow-templates/review.yml
+++ b/workflow-templates/review.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Review

--- a/workflow-templates/stale.yml
+++ b/workflow-templates/stale.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Stale

--- a/workflow-templates/stale.yml
+++ b/workflow-templates/stale.yml
@@ -1,11 +1,11 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Stale
 
-on:
+on: # yamllint disable-line rule:truthy
   schedule:
     - cron: "30 1 * * *"
 

--- a/workflow-templates/stale.yml
+++ b/workflow-templates/stale.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T19:18:56.879Z
+# Synced:  2026-07-08T19:30:52.886Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Stale

--- a/workflow-templates/stale.yml
+++ b/workflow-templates/stale.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Stale

--- a/workflow-templates/stale.yml
+++ b/workflow-templates/stale.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Stale

--- a/workflow-templates/stale.yml
+++ b/workflow-templates/stale.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-08T18:58:21.598Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Stale

--- a/workflow-templates/stale.yml
+++ b/workflow-templates/stale.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T18:58:21.598Z
+# Synced:  2026-07-08T19:18:56.879Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Stale

--- a/workflow-templates/test.yml
+++ b/workflow-templates/test.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Test

--- a/workflow-templates/test.yml
+++ b/workflow-templates/test.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T19:18:56.879Z
+# Synced:  2026-07-08T19:30:52.886Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Test

--- a/workflow-templates/test.yml
+++ b/workflow-templates/test.yml
@@ -1,12 +1,13 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Test
 
 on: # yamllint disable-line rule:truthy
   push:
+    branches: [main, alpha]
   pull_request:
 
 concurrency:
@@ -18,5 +19,6 @@ permissions:
 
 jobs:
   test:
+    name: Test
     uses: theholocron/.github/.github/workflows/test.yml@main
     secrets: inherit

--- a/workflow-templates/test.yml
+++ b/workflow-templates/test.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-08T18:58:21.598Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Test

--- a/workflow-templates/test.yml
+++ b/workflow-templates/test.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Test

--- a/workflow-templates/test.yml
+++ b/workflow-templates/test.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T18:58:21.598Z
+# Synced:  2026-07-08T19:18:56.879Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Test

--- a/workflow-templates/test.yml
+++ b/workflow-templates/test.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Test

--- a/workflow-templates/typecheck.yml
+++ b/workflow-templates/typecheck.yml
@@ -1,12 +1,13 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:43:02.701Z
+# Synced:  2026-07-08T17:54:47.218Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Typecheck
 
 on: # yamllint disable-line rule:truthy
   push:
+    branches: [main, alpha]
   pull_request:
 
 concurrency:
@@ -18,5 +19,6 @@ permissions:
 
 jobs:
   typecheck:
+    name: Typecheck
     uses: theholocron/.github/.github/workflows/typecheck.yml@main
     secrets: inherit

--- a/workflow-templates/typecheck.yml
+++ b/workflow-templates/typecheck.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T18:58:21.598Z
+# Synced:  2026-07-08T19:18:56.879Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Typecheck

--- a/workflow-templates/typecheck.yml
+++ b/workflow-templates/typecheck.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-08T18:58:21.598Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Typecheck

--- a/workflow-templates/typecheck.yml
+++ b/workflow-templates/typecheck.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T17:24:48.689Z
+# Synced:  2026-07-08T17:43:02.701Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Typecheck

--- a/workflow-templates/typecheck.yml
+++ b/workflow-templates/typecheck.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T15:41:32.412Z
+# Synced:  2026-07-08T16:19:57.592Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Typecheck

--- a/workflow-templates/typecheck.yml
+++ b/workflow-templates/typecheck.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T16:19:57.592Z
+# Synced:  2026-07-08T17:24:48.689Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Typecheck

--- a/workflow-templates/typecheck.yml
+++ b/workflow-templates/typecheck.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T19:18:56.879Z
+# Synced:  2026-07-08T19:30:52.886Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Typecheck


### PR DESCRIPTION
## Summary

Full CI infrastructure buildout for the org. Continues from PR #9 (vault removal).

### What's included

**Reusable workflows + composite actions**
- 11 `workflow_call` reusable workflows (`lint`, `test`, `typecheck`, `codeql`, `review`, `release`, `stale`, `greetings`, `dependencies`, `bookkeeping-pr`, `audit`)
- 3 composite actions (`setup`, `setup-node`, `install`) — all pnpm-only, no multi-PM complexity
- All third-party actions pinned to commit SHAs (supply chain security)
- Generated headers on all synced files (source path + timestamp)

**Workflow quality**
- `yamllint disable-line rule:truthy` on all `on:` keys
- `timeout-minutes` on every job
- Concurrency groups on all workflows
- Branch filters on `push:` triggers (`branches: [main, alpha]`) — eliminates duplicate runs on PRs
- `review.yml` PR-only with `github-pr-check` reporter (inline diff annotations)

**Labeler**
- `labeler.yml` updated for Conventional Commit title-regex patterns
- `bookkeeping-pr.yml` self-triggers on `.github`'s own PRs
- Labels created: `chore`, `ci`, `refactor`, `performance`, `test`

**README**
- Root README rewritten with full workflow/action docs and `holocron setup` quick start

**Config + Dependabot**
- `holocron.config.json` (balanced preset, no vault)
- `.github/dependabot.yml` with grouped security + version updates

## Post-merge

Run `pnpm holocron setup --cwd <this-checkout>` to apply branch protection and repo settings.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/.github/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->