### PR TITLE
chore: sync from theholocron/holocron@alpha (2026-07-09)

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/actions/install/action.yml
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Install dependencies

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/actions/setup-node/action.yml
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Setup Node

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/actions/setup/action.yml
-# Synced:  2026-07-08T17:54:47.218Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Setup

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/audit.yml
-# Synced:  2026-07-08T19:30:52.886Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Audit

--- a/.github/workflows/bookkeeping-pr.yml
+++ b/.github/workflows/bookkeeping-pr.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/bookkeeping-pr.yml
-# Synced:  2026-07-08T19:30:52.886Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: PR Bookkeeping

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/codeql.yml
-# Synced:  2026-07-08T19:30:52.886Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: CodeQL

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/dependencies.yml
-# Synced:  2026-07-08T19:30:52.886Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Dependencies

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/greetings.yml
-# Synced:  2026-07-08T19:30:52.886Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Greetings

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/lint.yml
-# Synced:  2026-07-08T19:30:52.886Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/release.yml
-# Synced:  2026-07-08T19:30:52.886Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Release
@@ -42,8 +42,12 @@ jobs:
       - uses: theholocron/.github/.github/actions/setup@main
         name: Setup
 
-      - run: npm install -g npm@11
+      - run: npm install -g npm@11 sigstore
         name: Upgrade npm for OIDC support
+        # sigstore is required by libnpmpublish/provenance.js at module parse
+        # time — before any config takes effect. Some npm 11.x builds stopped
+        # bundling it; installing it globally into the same prefix ensures it
+        # resolves regardless of npm version. (Discovered 2026-07-09.)
 
       - run: pnpm build
         name: Build

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/review.yml
-# Synced:  2026-07-08T19:30:52.886Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Review

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/stale.yml
-# Synced:  2026-07-08T19:30:52.886Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Stale

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/test.yml
-# Synced:  2026-07-08T19:30:52.886Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Test

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/workflows/typecheck.yml
-# Synced:  2026-07-08T19:30:52.886Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Typecheck

--- a/workflow-templates/audit.yml
+++ b/workflow-templates/audit.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T19:30:52.886Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Audit

--- a/workflow-templates/bookkeeping-pr.yml
+++ b/workflow-templates/bookkeeping-pr.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T19:30:52.886Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: PR Bookkeeping

--- a/workflow-templates/codeql.yml
+++ b/workflow-templates/codeql.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T19:30:52.886Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: CodeQL

--- a/workflow-templates/dependencies.yml
+++ b/workflow-templates/dependencies.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T19:30:52.886Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Dependencies

--- a/workflow-templates/greetings.yml
+++ b/workflow-templates/greetings.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T19:30:52.886Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Greetings

--- a/workflow-templates/lint.yml
+++ b/workflow-templates/lint.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T19:30:52.886Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Lint

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T19:30:52.886Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Release
@@ -9,12 +9,18 @@ on: # yamllint disable-line rule:truthy
   push:
     branches:
       - main
+      - alpha
+  workflow_dispatch:
 
 permissions:
   contents: write
   id-token: write
   issues: write
   pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   release:

--- a/workflow-templates/review.yml
+++ b/workflow-templates/review.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T19:30:52.886Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Review

--- a/workflow-templates/stale.yml
+++ b/workflow-templates/stale.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T19:30:52.886Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Stale

--- a/workflow-templates/test.yml
+++ b/workflow-templates/test.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T19:30:52.886Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Test

--- a/workflow-templates/typecheck.yml
+++ b/workflow-templates/typecheck.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Synced:  2026-07-08T19:30:52.886Z
+# Synced:  2026-07-09T16:15:03.018Z
 # Tool:    scripts/sync-github.mts
 # Changes: edit setup-workflows.ts in theholocron/holocron and push.
 name: Typecheck


### PR DESCRIPTION
## Summary

- `release.yml`: add `sigstore` to npm upgrade step — `libnpmpublish/provenance.js` requires it at module parse time; some npm 11.x builds stopped bundling it, breaking all publishes with `MODULE_NOT_FOUND`
- `workflow-templates/release.yml`: add `alpha` branch, `workflow_dispatch`, and `cancel-in-progress: false` concurrency guard to the release thin caller template
- All files: bump `Synced` timestamp

## Source

theholocron/holocron@alpha — generated by `scripts/sync-github.mts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/.github/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->