### PR TITLE
docs: add CLAUDE.md with repo conventions for Claude Code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,200 @@
+<!-- editorconfig-checker-disable-file -->
+
+# CLAUDE.md
+
+Conventions for working on `theholocron/.github`. Loaded automatically by
+Claude Code into every conversation in this repo.
+
+> **Local path:** `~/Code/theholocron/.github-repo/`
+> **GitHub repo:** `theholocron/.github`
+
+## What this repo is
+
+Org-level community health files, reusable CI workflows, composite actions,
+and workflow starter templates for the `theholocron` org. Other repos in the
+org call the reusable workflows here with `uses: theholocron/.github/.github/workflows/<name>.yml@main`.
+
+## Source of truth — what is generated vs. hand-maintained
+
+**Do not edit generated files directly in this repo.** They will be
+overwritten on the next sync.
+
+| Path | Owned here? | Source |
+|---|---|---|
+| `.github/workflows/*.yml` | **No — generated** | `holocron/packages/cli/src/templates/workflows/` |
+| `.github/actions/*/action.yml` | **No — generated** | `holocron/packages/cli/src/templates/actions/` |
+| `workflow-templates/*.yml` | **No — generated** | `holocron/packages/cli/src/templates/` |
+| `workflow-templates/*.properties.json` | **No — generated** | `holocron/packages/cli/src/templates/` |
+| `.github/ISSUE_TEMPLATE/` | Yes | Hand-maintained here |
+| `.github/pull_request_template.md` | Yes | Hand-maintained here |
+| `.github/CODEOWNERS` | Yes | Hand-maintained here |
+| `.github/labeler.yml` | Yes | Hand-maintained here |
+| `.github/dependabot.yml` | Yes | Hand-maintained here |
+| `.github/CONTRIBUTING.md` | Yes | Hand-maintained here |
+| `.github/CODE_OF_CONDUCT.md` | Yes | Hand-maintained here |
+| `.github/SECURITY.md` | Yes | Hand-maintained here |
+| `.github/GOVERNANCE.md` | Yes | Hand-maintained here |
+| `.github/SUPPORT.md` | Yes | Hand-maintained here |
+| `.github/FUNDING.yml` | Yes | Hand-maintained here |
+| `profile/` | Yes | Hand-maintained here |
+| `README.md` | Yes | Hand-maintained here |
+
+Every generated file begins with:
+
+```yaml
+# AUTO-GENERATED — do not edit in theholocron/.github directly.
+# Source:  theholocron/holocron · packages/cli/src/templates/index.ts
+# Synced:  <timestamp>
+# Tool:    holocron sync-github
+# Changes: edit source in theholocron/holocron and push to alpha or main.
+```
+
+## How to update a generated workflow or action
+
+1. Open `theholocron/holocron` (local path: `~/Code/theholocron/holocron/`)
+2. Edit `packages/cli/src/templates/workflows/<name>.yml` or
+   `packages/cli/src/templates/actions/<name>/action.yml`
+3. Push to `alpha` — **this is the active trigger branch right now** (see note below)
+4. The `sync-github.yml` CI workflow in `holocron` runs `holocron sync-github`,
+   opens a PR here on branch `chore/sync-templates`
+5. Review and merge that PR — do not hand-edit the generated files
+
+The sync command validates generated workflows with `actionlint` before
+opening the PR, so CI on the PR should pass cleanly.
+
+> **Note — `alpha` is the current sync trigger, not `main`.**
+> All v2 work in `holocron` lives on `alpha`; `main` still tracks the v1
+> stable line, so syncing from `main` would push stale templates. Once `alpha`
+> is merged to `main` and a stable release is cut, the sync trigger should be
+> flipped to fire on `main` pushes. Tracked in
+> [theholocron/.github#25](https://github.com/theholocron/.github/issues/25).
+
+## Action pinning — non-negotiable rule
+
+**Always pin third-party actions to a full commit SHA, never a tag.**
+
+```yaml
+# Correct
+- uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+# Wrong — tags are mutable and can be force-pushed
+- uses: actions/checkout@v7
+- uses: actions/checkout@v4.2.2
+```
+
+The only exception is **our own composite actions**, which are pinned to
+`@main` because we control the ref and it stays current automatically:
+
+```yaml
+- uses: theholocron/.github/.github/actions/setup@main
+- uses: theholocron/.github/.github/actions/setup-node@main
+- uses: theholocron/.github/.github/actions/install@main
+```
+
+When adding a new third-party action:
+1. Find the latest release tag on its GitHub releases page
+2. Click the tag → copy the full commit SHA from the URL or `git rev-parse`
+3. Use `owner/action@<sha> # v<version>` format
+
+## Composite actions (`.github/actions/`)
+
+Three actions exist. All are generated; edit the templates in `holocron` to change them.
+
+| Action | Purpose | Call |
+|---|---|---|
+| `setup` | Runs `setup-node` + `install` | `theholocron/.github/.github/actions/setup@main` |
+| `setup-node` | pnpm + Node 22 + pnpm cache | `theholocron/.github/.github/actions/setup-node@main` |
+| `install` | `pnpm install --frozen-lockfile` | `theholocron/.github/.github/actions/install@main` |
+
+## Reusable workflows (`.github/workflows/`)
+
+All workflows use `on: workflow_call` — they are not triggered directly.
+Caller repos call them with `uses: theholocron/.github/.github/workflows/<name>.yml@main`.
+
+| Workflow | Triggered by callers on | Purpose |
+|---|---|---|
+| `lint.yml` | push + PR | super-linter CI gate: Prettier, YAML, ESLint, Gitleaks, ActionLint |
+| `review.yml` | PR only | ReviewDog inline annotations: ESLint, tsc, ShellCheck, Hadolint, etc. |
+| `test.yml` | push + PR | vitest + Codecov |
+| `typecheck.yml` | push + PR | `pnpm typecheck` (`tsc --noEmit`) |
+| `codeql.yml` | push/PR to main + weekly | CodeQL security scan |
+| `release.yml` | push to main or alpha | semantic-release + OIDC Trusted Publishing |
+| `stale.yml` | daily schedule | marks stale issues/PRs |
+| `greetings.yml` | PR + issues | first-time contributor welcome |
+| `dependencies.yml` | PR | Dependabot semver-patch auto-merge |
+| `bookkeeping-pr.yml` | PR opened/edited | labels PRs from Conventional Commit title |
+| `audit.yml` | push + PR | BundleWatch bundle size |
+| `sync-github.yml` | push to main or alpha in `holocron` | re-generates and PRs these files |
+
+## Workflow starter templates (`workflow-templates/`)
+
+Each `<name>.yml` + `<name>.properties.json` pair powers the
+"By your organization" section in GitHub's Actions → New workflow UI.
+Templates are thin callers of the matching reusable workflow. Generated;
+edit source in `holocron`.
+
+## Which repos call these workflows
+
+Any `theholocron/*` repo with a `holocron.config.json` and a
+`pnpm holocron setup` run will have thin caller files in
+`.github/workflows/` that delegate to workflows here.
+
+Key repos in the org:
+- `theholocron/holocron` — the CLI source; also the origin of all syncs
+- `theholocron/configs` — shared config packages (`@theholocron/*-config`)
+- `theholocron/.github` — this repo
+
+The `sync-github` workflow in `holocron` can target multiple repos:
+- **Primary repo** (`theholocron/.github`) — receives composite actions +
+  reusable workflows + templates via PR (branch protection assumed)
+- **Secondary repos** — receive reusable workflows + thin callers via direct
+  push to main
+
+## `holocron setup` and `holocron.config.json`
+
+Repos that run `holocron setup` (using `@theholocron/cli`) have a
+`holocron.config.json` that declares which workflows they want:
+
+```jsonc
+{
+  "project": {
+    "name": "my-project",
+    "repo": "theholocron/my-project",
+    "workflows": ["lint", "test", "typecheck", "codeql", "review", "release"]
+  },
+  "providers": { "source": "github", "ci": "github", "secrets": "github" }
+}
+```
+
+`holocron setup` writes thin caller files to the repo's `.github/workflows/`
+that delegate to the reusable workflows here. It also sets repo settings,
+branch protection rulesets, and Dependabot config.
+
+This repo's own `holocron.config.json` uses `"preset": "balanced"` because
+it has no test or build workflows of its own.
+
+## Workflow
+
+- **Commits use Conventional Commits.** `ci:` for workflow changes, `docs:`
+  for community health files, `chore:` for maintenance.
+- **Always `git commit -s`** (DCO). `Signed-off-by:` trailer required.
+- **No Claude attribution** in commits, PRs, issues, or docs.
+- **One PR = one focused change.** Squash-merge.
+- For generated file updates, the sync mechanism opens the PR automatically —
+  don't manually apply those changes.
+
+## Quality
+
+- No test suite in this repo (no code logic to test).
+- `pnpm lint` runs `yamllint` on workflow files.
+- Generated workflows are validated by `actionlint` during the sync step in
+  `holocron` before the PR is opened here.
+- Branch protection on `main` requires the PR to pass CI before merge.
+
+## Releases
+
+This repo has no npm publish step. Changes take effect as soon as they land
+on `main` because callers reference `@main`.
+
+Community health files (CONTRIBUTING, CODE_OF_CONDUCT, etc.) are picked up
+by GitHub automatically from the org's `.github` repo — no deploy step needed.


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` so Claude Code has full context when returning to this repo
- Covers the action-pinning rule (SHA hashes for third-party actions, `@main` only for internal composite actions)
- Documents the generated-vs-hand-maintained file split and how to update generated files via the `holocron sync-github` flow
- Notes that `alpha` is the current sync trigger branch (not `main`) with a pointer to #25 for flipping that once v2 ships

## Test plan

- [ ] File renders correctly on GitHub
- [ ] Links to #25 resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/.github/pull/26" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->