### PR TITLE
fix(ci): scope GIT_COMMITLINT to PR base ref, not repo default branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,6 +51,7 @@ jobs:
         name: Run Super Linter
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          DEFAULT_BRANCH: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
           ANNOTATE_ONLY: true
           DISABLE_COMMENTS: false
           IGNORE_GITIGNORED_FILES: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,8 @@ overwritten on the next sync.
 
 | Path | Owned here? | Source |
 |---|---|---|
-| `.github/workflows/*.yml` | **No — generated** | `holocron/packages/cli/src/templates/workflows/` |
-| `.github/actions/*/action.yml` | **No — generated** | `holocron/packages/cli/src/templates/actions/` |
+| `.github/workflows/*.yml` | **No — generated** | `holocron/packages/cli/src/templates/index.ts` (`REUSABLE_WORKFLOWS`) |
+| `.github/actions/*/action.yml` | **No — generated** | `holocron/packages/cli/src/templates/index.ts` (`ACTIONS`) |
 | `workflow-templates/*.yml` | **No — generated** | `holocron/packages/cli/src/templates/` |
 | `workflow-templates/*.properties.json` | **No — generated** | `holocron/packages/cli/src/templates/` |
 | `.github/ISSUE_TEMPLATE/` | Yes | Hand-maintained here |
@@ -52,8 +52,9 @@ Every generated file begins with:
 ## How to update a generated workflow or action
 
 1. Open `theholocron/holocron` (local path: `~/Code/theholocron/holocron/`)
-2. Edit `packages/cli/src/templates/workflows/<name>.yml` or
-   `packages/cli/src/templates/actions/<name>/action.yml`
+2. Edit `packages/cli/src/templates/index.ts` — workflows are in the `REUSABLE_WORKFLOWS`
+   export, actions are in the `ACTIONS` export (the `workflows/` and `actions/` YAML files
+   were removed; `index.ts` is the single source of truth)
 3. Push to `alpha` — **this is the active trigger branch right now** (see note below)
 4. The `sync-github.yml` CI workflow in `holocron` runs `holocron sync-github`,
    opens a PR here on branch `chore/sync-templates`


### PR DESCRIPTION
## Summary

- Adds `DEFAULT_BRANCH: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}` to the super-linter env

Without this, super-linter always uses the repo's default branch (`main`) as the base for `GIT_COMMITLINT` range. For repos like `holocron` where active work is on `alpha`, PRs targeting `alpha` cause commitlint to scan every commit between `main` and `HEAD` — including old commits that predate the current `subject-case` and `type-enum` rules, causing false failures.

Setting `DEFAULT_BRANCH` dynamically to the PR's base ref limits the scan to only the commits actually in the PR.

## Test plan

- [ ] After merge, re-trigger CI on `theholocron/holocron#122` — `GIT_COMMITLINT` should pass

## Context

This file is auto-generated from `theholocron/holocron · packages/cli/src/templates/index.ts`. The same fix is included in that template as of `theholocron/holocron#122`, so the next `holocron sync-github` run will preserve this change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/.github/pull/28" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->