### PR TITLE
docs: update CLAUDE.md and add missing linter config files

### DIFF
--- a/.alexrc.json
+++ b/.alexrc.json
@@ -1,0 +1,11 @@
+{
+  "allow": [
+    "dead",
+    "failure",
+    "failures",
+    "hook",
+    "hooks",
+    "husky",
+    "period"
+  ]
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -12,12 +12,14 @@ indent_size = 4
 indent_style = space
 indent_size = 2
 
-[*.{json,yml}]
+[*.{json,yml,yaml}]
 indent_style = space
 indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
+indent_style = space
+indent_size = 2
 
 [.*{rc,ignore}]
 indent_style = space

--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -1,0 +1,23 @@
+{
+  "Version": "v3.7.0",
+  "Verbose": false,
+  "Format": "",
+  "Debug": false,
+  "IgnoreDefaults": false,
+  "SpacesAfterTabs": false,
+  "NoColor": false,
+  "Exclude": [
+    "(^|.+/)LICENSE$",
+    "^public/.*"
+  ],
+  "AllowedContentTypes": [],
+  "PassedFiles": [],
+  "Disable": {
+    "EndOfLine": false,
+    "Indentation": false,
+    "InsertFinalNewline": false,
+    "TrimTrailingWhitespace": false,
+    "IndentSize": false,
+    "MaxLineLength": false
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,5 @@
 @../github-private/CLAUDE.md
 
-@../github-private/CLAUDE.md
-
 # CLAUDE.md
 
 Conventions for working on `theholocron/.github`. Loaded automatically by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- editorconfig-checker-disable-file -->
+@../github-private/CLAUDE.md
 
 @../github-private/CLAUDE.md
 
@@ -39,7 +39,17 @@ overwritten on the next sync.
 | `.github/SUPPORT.md` | Yes | Hand-maintained here |
 | `.github/FUNDING.yml` | Yes | Hand-maintained here |
 | `profile/` | Yes | Hand-maintained here |
+| `.alexignore` | Yes | Hand-maintained here |
+| `.alexrc.json` | Yes | Hand-maintained here — keep in sync with org standard; no `package.json` so `holocron setup` cannot run here |
+| `.editorconfig` | Yes | Hand-maintained here |
+| `.editorconfig-checker.json` | Yes | Hand-maintained here — keep in sync with org standard; no `package.json` so `holocron setup` cannot run here |
+| `.gitattributes` | Yes | Hand-maintained here |
+| `.gitignore` | Yes | Hand-maintained here |
+| `CLAUDE.md` | Yes | Hand-maintained here |
+| `holocron.config.json` | Yes | Hand-maintained here |
+| `LICENSE` | Yes | Hand-maintained here |
 | `README.md` | Yes | Hand-maintained here |
+| `yamllint.config.yml` | Yes | Hand-maintained here |
 
 Every generated file begins with:
 
@@ -145,6 +155,8 @@ Any `theholocron/*` repo with a `holocron.config.json` and a
 Key repos in the org:
 - `theholocron/holocron` — the CLI source; also the origin of all syncs
 - `theholocron/configs` — shared config packages (`@theholocron/*-config`)
+- `theholocron/clients` — HTTP clients and API wrappers
+- `theholocron/.github-private` — internal member documentation
 - `theholocron/.github` — this repo
 
 The `sync-github` workflow in `holocron` can target multiple repos:


### PR DESCRIPTION
## Summary

- Removes `<!-- editorconfig-checker-disable-file -->` from CLAUDE.md
- Expands the maintenance table with all hand-maintained root files that were undocumented (`.alexignore`, `.alexrc.json`, `.editorconfig`, `.editorconfig-checker.json`, `.gitattributes`, `.gitignore`, `CLAUDE.md`, `holocron.config.json`, `LICENSE`, `yamllint.config.yml`)
- Adds `theholocron/clients` and `theholocron/.github-private` to the list of repos that call these workflows
- Adds `.alexrc.json` and `.editorconfig-checker.json` — both required by the `lint.yml` reusable workflow but missing. Hand-maintained to match org standard since this repo has no `package.json` to run `holocron setup`.

## Test plan

- [ ] CI passes
- [ ] Editorconfig and alex checks pass now that the config files are present
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/.github/pull/32" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->