### PR TITLE
chore(config): migrate to RepoConfig object with topics and properties

### DIFF
--- a/holocron.config.json
+++ b/holocron.config.json
@@ -2,9 +2,16 @@
   "project": {
     "name": ".github",
     "description": "Org-level community health files, reusable CI workflows, and workflow templates for theholocron.",
-    "repo": "theholocron/.github",
-    "repoPolicy": {
-      "preset": "balanced"
+    "repo": {
+      "name": "theholocron/.github",
+      "protection": "balanced",
+      "topics": ["github-actions", "github-config", "reusable-workflows"],
+      "properties": {
+        "lifecycle": "active",
+        "open_source": true,
+        "runtime_environment": "none",
+        "uses_external_packages": false
+      }
     }
   },
   "providers": {


### PR DESCRIPTION
## Summary

Migrates `holocron.config.json` from the deprecated `project.repo` string + `project.repoPolicy` shape to the new `RepoConfig` object introduced in theholocron/holocron#145.

- `project.repo` is now an object with `name`, `protection`, `topics`, and `properties`
- `project.repoPolicy` is removed
- Topics replace the stale `profile-readme` topic with `github-actions` and `reusable-workflows`

## Depends on

theholocron/holocron#145 must be merged and released before `holocron setup` will sync properties and topics from this config.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/.github/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->