### PR TITLE
chore: flatten holocron.config — promote project fields to root

### DIFF
--- a/holocron.config.json
+++ b/holocron.config.json
@@ -1,17 +1,15 @@
 {
-  "project": {
-    "name": ".github",
-    "description": "Org-level community health files, reusable CI workflows, and workflow templates for theholocron.",
-    "repo": {
-      "name": "theholocron/.github",
-      "protection": "balanced",
-      "topics": ["github-actions", "github-config", "reusable-workflows"],
-      "properties": {
-        "lifecycle": "active",
-        "open_source": true,
-        "runtime_environment": "none",
-        "uses_external_packages": false
-      }
+  "name": ".github",
+  "description": "Org-level community health files, reusable CI workflows, and workflow templates for theholocron.",
+  "repo": {
+    "name": "theholocron/.github",
+    "protection": "balanced",
+    "topics": ["github-actions", "github-config", "reusable-workflows"],
+    "properties": {
+      "lifecycle": "active",
+      "open_source": true,
+      "runtime_environment": "none",
+      "uses_external_packages": false
     }
   },
   "providers": {


### PR DESCRIPTION
## Summary

- Updates `holocron.config.json` to use the flat `HolocronConfig` shape introduced in theholocron/holocron (removes `project` wrapper, promotes `name`, `repo`, `workflows` to root)

## Test plan

- [ ] Confirm config loads correctly once the updated `@theholocron/cli` is published
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/theholocron/.github/pull/46" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->