### PR TITLE
chore: run holocron setup (alpha.71)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,9 @@
+# AUTO-GENERATED — do not edit directly.
+# Source:  theholocron/holocron · packages/cli/src/commands/setup.ts
+# Synced:  2026-07-21T22:20:29.370Z
+# Tool:    holocron setup
+# Changes: run `holocron setup` to regenerate.
+
 root = true
 
 [*]


### PR DESCRIPTION
## Summary

- Runs `holocron setup` via `npx @theholocron/cli@2.0.0-alpha.71`: 18 ok, 0 fail, 0 skipped
- `sync teams` registers repo with `gatekeepers`; `.editorconfig` timestamp updated
- `codecov.yml` (empty components) excluded — no test suite in this repo