### PR TITLE
ci: add knip job to audit workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,6 +1,6 @@
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
 # Source:  theholocron/holocron · packages/cli/src/templates/index.ts
-# Synced:  2026-07-21T20:57:17.269Z
+# Synced:  2026-07-22T00:00:00.000Z
 # Tool:    holocron sync-github
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Audit
@@ -13,6 +13,16 @@ on: # yamllint disable-line rule:truthy
         type: string
         required: false
         default: pnpm build
+      run-knip:
+        description: Run Knip to detect unused files, exports, and dependencies
+        type: boolean
+        required: false
+        default: false
+      knip-script:
+        description: Script that invokes Knip (must exit non-zero on findings)
+        type: string
+        required: false
+        default: pnpm run audit
     secrets:
       CODECOV_TOKEN:
         required: false
@@ -41,3 +51,24 @@ jobs:
         env:
           BUILD_SCRIPT: ${{ inputs.build-script }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  knip:
+    name: Knip
+    if: ${{ inputs.run-knip }}
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        name: Checkout repository
+        with:
+          persist-credentials: false
+
+      - uses: theholocron/.github/.github/actions/setup@main
+        name: Setup
+
+      - run: eval "$KNIP_SCRIPT"
+        name: Run Knip
+        env:
+          KNIP_SCRIPT: ${{ inputs.knip-script }}


### PR DESCRIPTION
## Summary

- Adds a `knip` job to the shared `audit` reusable workflow
- Gated behind a `run-knip: boolean` input (default `false`) so existing callers are unaffected
- Accepts an optional `knip-script` input (default `pnpm run audit`) for flexibility
- Uses the standard `theholocron/.github/.github/actions/setup` composite action for consistency

## Merge order

Merge this **before** the matching PRs in `theholocron/holocron` (template source) and `theholocron/clients` (first consumer). The `.github` reusable workflow is what callers reference at `@main`.