### PR TITLE
fix: clear NODE_AUTH_TOKEN — superseded by #78

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,10 @@
 # Changes: edit source in theholocron/holocron and push to alpha or main.
 name: Release
 
-# Semantic-release with OIDC Trusted Publishing — no NPM_TOKEN required.
+# Semantic-release with OIDC Trusted Publishing.
+# actions/setup-node writes a default NODE_AUTH_TOKEN=${{ github.token }}
+# which shadows OIDC auth. We explicitly clear it so npm falls through to
+# the Trusted Publisher OIDC exchange.
 # The calling repo must have a .releaserc.json that configures branches,
 # plugins, and any publish options. npm@11+ is installed to support OIDC.
 
@@ -129,6 +132,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.HOLOCRON_RELEASE_TOKEN || secrets.HOLOCRON_SYNC_TOKEN || github.token }}
           HUSKY: "0"
           NPM_CONFIG_PROVENANCE: true
+          # actions/setup-node writes a default NODE_AUTH_TOKEN=${{ github.token }}
+          # which shadows the OIDC Trusted Publishing exchange. Explicitly clear it.
+          NODE_AUTH_TOKEN: ""
 
       - name: Get release version
         id: release_version


### PR DESCRIPTION
Superseded by #78 which uses a more correct approach (deleting the config key rather than setting it to empty string). Please close this and merge #78 instead.