### PR TITLE
fix: make Cypress wait-on URL configurable via wait-on-url input

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,11 @@ on: # yamllint disable-line rule:truthy
         type: boolean
         required: false
         default: false
+      wait-on-url:
+        description: URL to wait for before running Cypress tests (default is Vite dev server; override for non-Vite stacks e.g. http://localhost:3000 for Next.js)
+        type: string
+        required: false
+        default: "http://localhost:5173"
     secrets:
       CHROMATIC_PROJECT_TOKEN:
         required: false
@@ -192,7 +197,7 @@ jobs:
         name: Cypress run
         with:
           start: pnpm dev
-          wait-on: "http://localhost:5173"
+          wait-on: ${{ inputs.wait-on-url }}
           record: true
           parallel: true
         env:


### PR DESCRIPTION
## Summary

- Add `wait-on-url` string input to the `test.yml` workflow (default: `http://localhost:5173` preserves existing behaviour)
- Thread it through to `cypress-io/github-action`'s `wait-on` parameter

## Why

The hardcoded `http://localhost:5173` only works for Vite dev servers. Next.js runs on port 3000, and other frameworks use other ports — they all time out waiting for a server that never starts on 5173.

## Test plan

- [ ] Verify existing Vite-based repos still pass (default unchanged)
- [ ] Verify `theholocron/nextjs-template` user-flow tests pass with `wait-on-url: http://localhost:3000`

Closes #110
🤖 Generated with [Claude Code](https://claude.com/claude-code)