### PR TITLE
fix(lint): use detect step output to gate ESLint config and VALIDATE_ flags

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -114,6 +114,8 @@ jobs:
         id: detect
         run: |
           has() { find . -not -path '*/node_modules/*' -name "$1" -print -quit 2>/dev/null | grep -q .; }
+          { has 'eslint.config.ts' || has 'eslint.config.mjs' || has 'eslint.config.js' || has '.eslintrc.json' || has '.eslintrc.yml'; } \
+            && echo "eslint=true" >> "$GITHUB_OUTPUT" || echo "eslint=false" >> "$GITHUB_OUTPUT"
           { has '*.js' || has '*.jsx' || has '*.mjs' || has '*.cjs' || has '*.ts' || has '*.tsx'; } \
             && echo "js=true" >> "$GITHUB_OUTPUT" || echo "js=false" >> "$GITHUB_OUTPUT"
           { has '*.css' || has '*.scss' || has 'stylelint.config.ts' || has 'stylelint.config.mjs' || has 'stylelint.config.js'; } \
@@ -137,11 +139,13 @@ jobs:
           IGNORE_GITIGNORED_FILES: true
           LINTER_RULES_PATH: /
           EDITORCONFIG_FILE_NAME: ".editorconfig-checker.json"
-          # Config paths: inputs stay in expression context, never in run: scripts.
-          # hashFiles() returns '' when the file is absent so super-linter falls
-          # back to its own built-in default rather than terminating.
-          JAVASCRIPT_ES_CONFIG_FILE: ${{ hashFiles(inputs.eslint-config) != '' && inputs.eslint-config || '' }}
-          TYPESCRIPT_ES_CONFIG_FILE: ${{ hashFiles(inputs.eslint-config) != '' && inputs.eslint-config || '' }}
+          # When eslint=false the config falls back to '', which makes super-linter
+          # use its built-in default (eslint.config.mjs) that ships in the container.
+          # VALIDATE_JAVASCRIPT_ES/TYPESCRIPT_ES must be explicitly true/false.
+          JAVASCRIPT_ES_CONFIG_FILE: ${{ steps.detect.outputs.eslint == 'true' && inputs.eslint-config || '' }}
+          TYPESCRIPT_ES_CONFIG_FILE: ${{ steps.detect.outputs.eslint == 'true' && inputs.eslint-config || '' }}
+          VALIDATE_JAVASCRIPT_ES: ${{ steps.detect.outputs.eslint == 'true' }}
+          VALIDATE_TYPESCRIPT_ES: ${{ steps.detect.outputs.eslint == 'true' }}
           PRETTIER_CONFIG: ${{ inputs.prettier-config }}
           TYPESCRIPT_STANDARD_TSCONFIG_FILE: ${{ inputs.typescript-tsconfig }}
           YAML_CONFIG_FILE: ${{ inputs.yaml-config }}


### PR DESCRIPTION
Follow-up to #114.

## What changed

- Detect step now writes `eslint=true/false` based on whether an ESLint config file is present (`eslint.config.ts`, `.mjs`, `.js`, `.eslintrc.json`, `.eslintrc.yml`)
- `JAVASCRIPT_ES_CONFIG_FILE` and `TYPESCRIPT_ES_CONFIG_FILE` use `steps.detect.outputs.eslint` instead of `hashFiles()` — avoids the ambiguous evaluation context of `hashFiles()` in reusable workflows
- `VALIDATE_JAVASCRIPT_ES` and `VALIDATE_TYPESCRIPT_ES` are now explicitly `true`/`false`

## Why

When no ESLint config is present:
- `JAVASCRIPT_ES_CONFIG_FILE=''` → super-linter globals default to `eslint.config.mjs` → found at `/action/lib/.automation/eslint.config.mjs` → startup validation passes
- `VALIDATE_JAVASCRIPT_ES=false` → ESLint does not run

Fixes `base-template` lint CI.