### PR TITLE
fix(lint): do not auto-enable ESLint via super-linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -116,11 +116,6 @@ jobs:
         run: |
           has() { find . -not -path '*/node_modules/*' -name "$1" -print -quit 2>/dev/null | grep -q .; }
 
-          if { has 'eslint.config.ts' || has 'eslint.config.mjs' || has 'eslint.config.js' || has '.eslintrc.json' || has '.eslintrc.yml'; }; then
-            echo "VALIDATE_JAVASCRIPT_ES=true" >> "$GITHUB_ENV"
-            echo "VALIDATE_TYPESCRIPT_ES=true" >> "$GITHUB_ENV"
-          fi
-
           if { has '*.js' || has '*.jsx' || has '*.mjs' || has '*.cjs' || has '*.ts' || has '*.tsx'; }; then
             echo "VALIDATE_JAVASCRIPT_PRETTIER=true" >> "$GITHUB_ENV"
             echo "VALIDATE_JSX_PRETTIER=true" >> "$GITHUB_ENV"


### PR DESCRIPTION
ESLint was never run by super-linter before PR #309 added the eslint-config input; `pnpm lint` handles ESLint in a dedicated step. Auto-enabling `VALIDATE_JAVASCRIPT_ES`/`TYPESCRIPT_ES` from the detect step surfaced pre-existing issues managed by `pnpm lint`. Keep `JAVASCRIPT_ES_CONFIG_FILE` conditional so startup validation passes, but leave the VALIDATE_ flags out of the allowlist.