### PR TITLE
fix(ci): restrict interaction job to chromium only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -195,11 +195,11 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-chromium-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
 
-      - run: pnpm exec playwright install --with-deps
+      - run: pnpm exec playwright install chromium --with-deps
         name: Install Playwright
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
-      - run: pnpm exec playwright install-deps
+      - run: pnpm exec playwright install-deps chromium
         name: Install Playwright system dependencies
         if: steps.playwright-cache.outputs.cache-hit == 'true'
 


### PR DESCRIPTION
## Summary

The interaction-and-accessibility job was using `playwright install --with-deps` with no browser specified, which downloads all three browsers (Chromium, Firefox, WebKit — ~600MB). Storybook and interaction tests only use Chromium. This caused consistent 20-minute timeouts even after the playwright caching PR (#134).

- Change `playwright install --with-deps` → `playwright install chromium --with-deps`
- Change `playwright install-deps` → `playwright install-deps chromium` (cache hit path)

## Test plan

- [ ] Interaction job completes well under the 20-minute timeout
- [ ] Cache key (`playwright-chromium-*`) now correctly describes what's cached

🤖 Generated with [Claude Code](https://claude.com/claude-code)