### PR TITLE
perf(ci): skip playwright install-deps on cache hit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,9 +120,7 @@ jobs:
         name: Install Playwright
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
-      - run: pnpm exec playwright install-deps chromium
-        name: Install Playwright system dependencies
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
+      # ubuntu-24.04 ships with Chromium system dependencies — skip apt on cache hit
 
       - run: pnpm test:storybook
         name: Run Storybook tests
@@ -199,9 +197,7 @@ jobs:
         name: Install Playwright
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
-      - run: pnpm exec playwright install-deps chromium
-        name: Install Playwright system dependencies
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
+      # ubuntu-24.04 ships with Chromium system dependencies — skip apt on cache hit
 
       - run: pnpm test:storybook
         name: Run interaction and accessibility tests


### PR DESCRIPTION
## Summary

On playwright browser cache hit, the previous code still ran `playwright install-deps chromium` which triggers `apt-get update` + package installs. The Ubuntu apt mirrors are intermittently slow/hung, causing 10–15 minute stalls even when the browser binary is already cached.

The ubuntu-24.04 GitHub-hosted runner ships with Chromium and its system dependencies pre-installed (it includes Chrome). Playwright's chromium deps are a subset of those, so they're already present on the runner — `install-deps` is redundant on cache hit.

- Remove the `playwright install-deps` step on cache hit for both storybook and interaction jobs
- Cache miss path is unchanged: `playwright install chromium --with-deps` runs as before

## Test plan

- [ ] Cache hit run: jobs complete in under 5 minutes (no apt delay)
- [ ] Cache miss run (lockfile change): full install still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)