### PR TITLE
fix(ci): 🐛 drop --with-deps from playwright install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,9 +120,7 @@ jobs:
         name: Install Playwright
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
-      - run: pnpm exec playwright install-deps chromium
-        name: Install Playwright system dependencies
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
+      # ubuntu-24.04 ships with Chromium system dependencies — skip apt on cache hit
 
       - run: pnpm test:storybook
         name: Run Storybook tests
@@ -199,9 +197,7 @@ jobs:
         name: Install Playwright
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
-      - run: pnpm exec playwright install-deps chromium
-        name: Install Playwright system dependencies
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
+      # ubuntu-24.04 ships with Chromium system dependencies — skip apt on cache hit
 
       - run: pnpm test:storybook
         name: Run interaction and accessibility tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,13 +116,11 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-chromium-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
 
-      - run: pnpm exec playwright install chromium --with-deps
+      - run: pnpm exec playwright install chromium
         name: Install Playwright
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        env:
-          DEBIAN_FRONTEND: noninteractive
 
-      # ubuntu-24.04 ships with Chromium system dependencies — skip apt on cache hit
+      # ubuntu-24.04 ships with Chromium system dependencies; no --with-deps needed
 
       - run: pnpm test:storybook
         name: Run Storybook tests
@@ -195,13 +193,11 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-chromium-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
 
-      - run: pnpm exec playwright install chromium --with-deps
+      - run: pnpm exec playwright install chromium
         name: Install Playwright
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        env:
-          DEBIAN_FRONTEND: noninteractive
 
-      # ubuntu-24.04 ships with Chromium system dependencies — skip apt on cache hit
+      # ubuntu-24.04 ships with Chromium system dependencies; no --with-deps needed
 
       - run: pnpm test:storybook
         name: Run interaction and accessibility tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,8 @@ jobs:
       - run: pnpm exec playwright install chromium --with-deps
         name: Install Playwright
         if: steps.playwright-cache.outputs.cache-hit != 'true'
+        env:
+          DEBIAN_FRONTEND: noninteractive
 
       # ubuntu-24.04 ships with Chromium system dependencies — skip apt on cache hit
 
@@ -196,6 +198,8 @@ jobs:
       - run: pnpm exec playwright install chromium --with-deps
         name: Install Playwright
         if: steps.playwright-cache.outputs.cache-hit != 'true'
+        env:
+          DEBIAN_FRONTEND: noninteractive
 
       # ubuntu-24.04 ships with Chromium system dependencies — skip apt on cache hit
 


### PR DESCRIPTION
## Summary

- Removes \`--with-deps\` from \`playwright install chromium\` in both the \`storybook\` and \`interaction-and-accessibility\` jobs
- \`--with-deps\` triggers \`apt-get install\` for Chromium system libraries, which can hang indefinitely on GitHub Actions runners due to dpkg lock contention from the \`unattended-upgrades\` service running in the background
- ubuntu-24.04 runners ship with Chromium system dependencies pre-installed, so \`--with-deps\` is unnecessary; just downloading the browser binary is sufficient

## Test plan

- [ ] Storybook job completes without hanging on "Install Playwright"