### PR TITLE
fix(test): revert secrets: inherit — fixes workflow file issue on PR events

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,10 +52,6 @@ on: # yamllint disable-line rule:truthy
     secrets:
       CHROMATIC_PROJECT_TOKEN:
         required: false
-      CHROMATIC_PROJECT_TOKEN_WEB:
-        required: false
-      CHROMATIC_PROJECT_TOKEN_UI:
-        required: false
       CYPRESS_RECORD_KEY:
         required: false
       TURBO_TOKEN:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,17 @@ on: # yamllint disable-line rule:truthy
         type: string
         required: false
         default: "http://localhost:5173"
-    secrets: inherit
+    secrets:
+      CHROMATIC_PROJECT_TOKEN:
+        required: false
+      CHROMATIC_PROJECT_TOKEN_WEB:
+        required: false
+      CHROMATIC_PROJECT_TOKEN_UI:
+        required: false
+      CYPRESS_RECORD_KEY:
+        required: false
+      TURBO_TOKEN:
+        required: false
 
 jobs:
   unit:


### PR DESCRIPTION
## Summary

Reverts the `secrets: inherit` shorthand in `on.workflow_call.secrets` back to explicit secret declarations. Adds `CHROMATIC_PROJECT_TOKEN_WEB` and `CHROMATIC_PROJECT_TOKEN_UI` to preserve multi-project Chromatic support for the monorepos.

## Why

`secrets: inherit` at the reusable workflow's `on.workflow_call.secrets` level (introduced in #139) causes a "workflow file issue" on `pull_request` events across all repos — 0 jobs, 0s runtime. Push events to main work fine. The explicit-secrets form does not have this problem.

`CHROMATIC_PROJECT_TOKEN_WEB` and `CHROMATIC_PROJECT_TOKEN_UI` are added explicitly so monorepo matrix jobs (`tokenName: "WEB"`, `tokenName: "UI"`) continue resolving the right token via `secrets[format('CHROMATIC_PROJECT_TOKEN_{0}', matrix.project.tokenName)]`.

## Test plan

- [ ] Merge → verify `Test` workflow passes on a PR in any consuming repo
