### PR TITLE
docs: update workflow and action inventory — add auto-commit, deploy, sync, sync-broadcast

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,33 +102,39 @@ When adding a new third-party action:
 
 ## Composite actions (`.github/actions/`)
 
-Three actions exist. All are generated; edit the templates in `holocron` to change them.
+Four actions exist. All are generated; edit the templates in `holocron` to change them.
 
 | Action | Purpose | Call |
 |---|---|---|
+| `auto-commit` | Commit + push file changes to a branch; outputs `changes-detected` | `theholocron/.github/.github/actions/auto-commit@main` |
+| `install` | `pnpm install --frozen-lockfile` | `theholocron/.github/.github/actions/install@main` |
 | `setup` | Runs `setup-node` + `install` | `theholocron/.github/.github/actions/setup@main` |
 | `setup-node` | pnpm + Node 22 + pnpm cache | `theholocron/.github/.github/actions/setup-node@main` |
-| `install` | `pnpm install --frozen-lockfile` | `theholocron/.github/.github/actions/install@main` |
 
 ## Reusable workflows (`.github/workflows/`)
 
-All workflows use `on: workflow_call` — they are not triggered directly.
-Caller repos call them with `uses: theholocron/.github/.github/workflows/<name>.yml@main`.
+Most workflows use `on: workflow_call` and are called with
+`uses: theholocron/.github/.github/workflows/<name>.yml@main`.
+`sync-broadcast.yml` uses `on: workflow_dispatch` instead — it is dispatched
+programmatically, not called via `workflow_call`.
 
-| Workflow | Triggered by callers on | Purpose |
+| Workflow | Trigger / call | Purpose |
 |---|---|---|
-| `lint.yml` | push + PR | super-linter CI gate: Prettier, YAML, ESLint, Gitleaks, ActionLint |
-| `review.yml` | PR only | ReviewDog inline annotations: ESLint, tsc, ShellCheck, Hadolint, etc. |
-| `test.yml` | push + PR | vitest + Codecov |
-| `typecheck.yml` | push + PR | `pnpm typecheck` (`tsc --noEmit`) |
-| `codeql.yml` | push/PR to main + weekly | CodeQL security scan |
-| `release.yml` | push to main | semantic-release + OIDC Trusted Publishing |
-| `stale.yml` | daily schedule | marks stale issues/PRs |
-| `greetings.yml` | PR + issues | first-time contributor welcome |
-| `dependencies.yml` | PR | Dependabot semver-patch auto-merge |
+| `audit.yml` | push + PR | BundleWatch bundle size + Knip unused-export analysis |
 | `bookkeeping.yml` | PR opened/edited | labels PRs from Conventional Commit title |
-| `audit.yml` | push + PR | BundleWatch bundle size |
-| `sync-github.yml` | push to main in `holocron` | re-generates and PRs these files |
+| `codeql.yml` | push/PR to main + weekly | CodeQL security scan |
+| `dependencies.yml` | PR | Dependabot semver-patch auto-merge |
+| `deploy.yml` | push to main | Astro/Storybook site deploy (Cloudflare Pages) |
+| `greetings.yml` | PR + issues | first-time contributor welcome |
+| `lint.yml` | push + PR | super-linter CI gate: Prettier, YAML, ESLint, Gitleaks, ActionLint |
+| `release.yml` | push to main | semantic-release + OIDC Trusted Publishing |
+| `review.yml` | PR only | ReviewDog inline annotations: ESLint, tsc, ShellCheck, Hadolint, etc. |
+| `stale.yml` | daily schedule | marks stale issues/PRs |
+| `sync-broadcast.yml` | `workflow_dispatch` | discovers all repos with `sync.yml` via GitHub API and dispatches `workflow_dispatch` to each; used by `post-release.yml` in `docs` |
+| `sync-github.yml` | push to main/alpha in `holocron` | re-generates and PRs these files |
+| `sync.yml` | `workflow_call` | runs `holocron sync` with optional `--steps`, auto-commits changes, opens a PR |
+| `test.yml` | push + PR | vitest + Codecov; optional Storybook, Chromatic, Cypress, Playwright jobs |
+| `typecheck.yml` | push + PR | `pnpm typecheck` (`tsc --noEmit`) |
 
 ## Workflow starter templates (`workflow-templates/`)
 

--- a/README.md
+++ b/README.md
@@ -29,17 +29,21 @@ which writes and maintains these files automatically from `holocron.config.json`
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `lint.yml` | push + PR | super-linter CI gate — Prettier, YAML, ESLint configs, Gitleaks, ActionLint |
-| `test.yml` | push + PR | vitest + Codecov coverage upload |
-| `typecheck.yml` | push + PR | `pnpm typecheck` (`tsc --noEmit`) |
-| `codeql.yml` | push/PR to main + weekly | CodeQL security scan (javascript-typescript) |
-| `review.yml` | PR only | ReviewDog annotation layer — ESLint, tsc, ShellCheck, Hadolint, ActionLint, Gitleaks, YamlLint, dotenv-linter, Alex |
-| `release.yml` | push to main | semantic-release + OIDC Trusted Publishing (no `NPM_TOKEN` needed) |
-| `stale.yml` | daily schedule | marks stale issues/PRs |
-| `greetings.yml` | PR + issues | first-time contributor welcome message |
-| `dependencies.yml` | PR | Dependabot auto-merge for semver-patch updates |
+| `audit.yml` | push + PR | BundleWatch bundle size + Knip unused-export analysis |
 | `bookkeeping.yml` | PR opened/edited | labels PRs from Conventional Commit title (`fix:` → bug, `feat:` → enhancement, etc.) |
-| `audit.yml` | push + PR | BundleWatch bundle size analysis |
+| `codeql.yml` | push/PR to main + weekly | CodeQL security scan (javascript-typescript) |
+| `dependencies.yml` | PR | Dependabot auto-merge for semver-patch updates |
+| `deploy.yml` | push to main | Astro/Storybook site deploy (Cloudflare Pages) |
+| `greetings.yml` | PR + issues | first-time contributor welcome message |
+| `lint.yml` | push + PR | super-linter CI gate — Prettier, YAML, ESLint configs, Gitleaks, ActionLint |
+| `release.yml` | push to main | semantic-release + OIDC Trusted Publishing (no `NPM_TOKEN` needed) |
+| `review.yml` | PR only | ReviewDog annotation layer — ESLint, tsc, ShellCheck, Hadolint, ActionLint, Gitleaks, YamlLint, dotenv-linter, Alex |
+| `stale.yml` | daily schedule | marks stale issues/PRs |
+| `sync-broadcast.yml` | `workflow_dispatch` | discovers all repos with `sync.yml` via GitHub API and fans out a dispatch; triggered by `post-release.yml` in `docs` |
+| `sync-github.yml` | push to main/alpha in `holocron` | re-generates and PRs these files |
+| `sync.yml` | `workflow_call` | runs `holocron sync` with optional `--steps`, auto-commits, opens PR |
+| `test.yml` | push + PR | vitest + Codecov; optional Storybook, Chromatic, Cypress, Playwright jobs |
+| `typecheck.yml` | push + PR | `pnpm typecheck` (`tsc --noEmit`) |
 
 Each workflow accepts inputs to customise behaviour — see the workflow files in
 `.github/workflows/` for the full input/secret declarations.
@@ -54,9 +58,10 @@ Reusable action steps callable from any workflow:
 
 | Action | Purpose |
 |---|---|
+| `auto-commit` | Commit + push file changes to a branch; outputs `changes-detected` |
+| `install` | `pnpm install --frozen-lockfile` |
 | `setup` | Orchestrates `setup-node` + `install` in one step |
 | `setup-node` | pnpm + Node 22 with pnpm dependency caching |
-| `install` | `pnpm install --frozen-lockfile` |
 
 ## Workflow starter templates
 


### PR DESCRIPTION
## Summary

- `AGENTS.md`: updates composite actions count (3 → 4, adds `auto-commit`); updates reusable workflows table (adds `deploy`, `sync`, `sync-broadcast`); adds note that `sync-broadcast.yml` uses `workflow_dispatch` not `workflow_call`
- `README.md`: same additions to the public-facing workflow and composite action tables

All four additions were already live in this repo — this is documentation catch-up after PRs #401 and #404 merged.