### PR TITLE
fix(ci): add DCO probot config to allow remediation commits

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+allowRemediationCommits:
+  individual: true


### PR DESCRIPTION
## Summary

- Adds `.github/dco.yml` with `allowRemediationCommits.individual: true`
- Probot/dco already excludes bot commits and merge commits by default, so no additional config is needed for that
- This setting lets a PR author push a signed follow-up commit (`git commit --allow-empty -s`) to resolve DCO failures instead of force-pushing a rewritten branch

## Test plan

- [ ] Merge this PR
- [ ] Open a test PR with an unsigned commit; verify the DCO check fails with a remediation prompt
- [ ] Push a signed empty commit to that branch; verify the DCO check passes

Closes #172