### PR TITLE
fix: accept FERN_TOKEN fallback in wiki.yml

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -33,7 +33,9 @@ on: # yamllint disable-line rule:truthy
         default: ""
     secrets:
       HOLOCRON_FERN_TOKEN:
-        required: true
+        required: false
+      FERN_TOKEN:
+        required: false
 
 jobs:
   publish:
@@ -55,11 +57,11 @@ jobs:
         if: ${{ !inputs.preview }}
         run: fern generate --docs
         env:
-          FERN_TOKEN: ${{ secrets.HOLOCRON_FERN_TOKEN }}
+          FERN_TOKEN: ${{ secrets.HOLOCRON_FERN_TOKEN || secrets.FERN_TOKEN }}
 
       - name: Preview docs
         if: ${{ inputs.preview && inputs.preview-id != '' }}
         run: fern generate --docs --preview --id "$PREVIEW_ID"
         env:
-          FERN_TOKEN: ${{ secrets.HOLOCRON_FERN_TOKEN }}
+          FERN_TOKEN: ${{ secrets.HOLOCRON_FERN_TOKEN || secrets.FERN_TOKEN }}
           PREVIEW_ID: ${{ inputs.preview-id }}


### PR DESCRIPTION
Declare both HOLOCRON_FERN_TOKEN (preferred) and FERN_TOKEN as optional secrets with || fallback, matching the plugin auth.ts resolution chain. Orgs with an existing FERN_TOKEN secret work without renaming it.