### PR TITLE
docs: ✨ add sentiment-bot config

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,9 @@
+# Configuration for sentiment-bot - https://github.com/behaviorbot/sentiment-bot
+
+# *Required* toxicity threshold between 0 and .99 with the higher numbers being the most toxic
+# Anything higher than this threshold will be marked as toxic and commented on
+sentimentBotToxicityThreshold: .7
+
+# *Required* Comment to reply with
+sentimentBotReplyComment: >
+  Please be sure to review the [Code of Conduct](https://docs.theholocron.dev/reference/code-of-conduct/) and be respectful of other users.


### PR DESCRIPTION
## Summary

- Adds `.github/config.yml` with sentiment-bot configuration
- Sets toxicity threshold at `0.7`
- Replies with a link to the Code of Conduct when a toxic comment is detected

The config lives in the org-level `.github` repo so it applies to all repos in the org where the sentiment-bot app is installed.

## Test plan

- [ ] Post a comment with negative sentiment on any issue or PR in the org and confirm the bot replies