### PR TITLE
docs: 📝 point the generated-file source at @theholocron/astromech

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,10 +21,10 @@ overwritten on the next sync.
 
 | Path | Owned here? | Source |
 |---|---|---|
-| `.github/workflows/*.yml` | **No — generated** | `holocron/packages/cli/src/templates/index.ts` (`REUSABLE_WORKFLOWS`) |
-| `.github/actions/*/action.yml` | **No — generated** | `holocron/packages/cli/src/templates/index.ts` (`ACTIONS`) |
-| `workflow-templates/*.yml` | **No — generated** | `holocron/packages/cli/src/templates/` |
-| `workflow-templates/*.properties.json` | **No — generated** | `holocron/packages/cli/src/templates/` |
+| `.github/workflows/*.yml` | **No — generated** | `holocron/packages/astromech/src/reusable.ts` (`REUSABLE_WORKFLOWS`; `.yml` in `src/templates/reusable/`) |
+| `.github/actions/*/action.yml` | **No — generated** | `holocron/packages/astromech/src/reusable.ts` (`REUSABLE_ACTIONS`; `.yml` in `src/templates/reusable/actions/`) |
+| `workflow-templates/*.yml` | **No — generated** | `holocron/packages/astromech/src/reusable.ts` (`reusableTemplates()`) |
+| `workflow-templates/*.properties.json` | **No — generated** | `holocron/packages/astromech/src/reusable.ts` (`WORKFLOW_TEMPLATE_PROPERTIES`) |
 | `.github/ISSUE_TEMPLATE/` | Yes | Hand-maintained here |
 | `.github/pull_request_template.md` | Yes | Hand-maintained here |
 | `.github/CODEOWNERS` | Yes | Hand-maintained here |
@@ -53,18 +53,18 @@ Every generated file begins with:
 
 ```yaml
 # AUTO-GENERATED — do not edit in theholocron/.github directly.
-# Source:  theholocron/holocron · packages/cli/src/templates/index.ts
+# Source:  theholocron/holocron · packages/astromech/src/reusable.ts
 # Synced:  <timestamp>
 # Tool:    holocron sync-github
-# Changes: edit source in theholocron/holocron and push to main.
+# Changes: edit source in theholocron/holocron
 ```
 
 ## How to update a generated workflow or action
 
 1. Open `theholocron/holocron` (local path: `~/Code/theholocron/holocron/`)
-2. Edit `packages/cli/src/templates/index.ts` — workflows are in the `REUSABLE_WORKFLOWS`
-   export, actions are in the `ACTIONS` export (the `workflows/` and `actions/` YAML files
-   were removed; `index.ts` is the single source of truth)
+2. Edit the `.yml` in `packages/astromech/src/templates/reusable/` (workflows) or
+   `packages/astromech/src/templates/reusable/actions/` (actions); `reusable.ts`
+   maps them into `REUSABLE_WORKFLOWS` / `REUSABLE_ACTIONS`
 3. Push to `main`
 4. The `sync-github.yml` CI workflow in `holocron` runs `holocron sync-github`,
    opens a PR here on branch `chore/sync-templates`

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 Org-level community health files, reusable CI workflows, and workflow templates.
 <!-- /holocron:description -->
 
+> **This repo is a pure sync target.** `.github/workflows/*`, `.github/actions/*`
+> and `workflow-templates/*` are **generated** from
+> `packages/astromech/src/templates/` in
+> [`theholocron/holocron`](https://github.com/theholocron/holocron) and pushed
+> here by `holocron sync-github` — every file carries an "AUTO-GENERATED — do not
+> edit" header. Change a reusable workflow by editing the source there; the sync
+> opens a PR against this repo.
+
 ## Using reusable workflows
 
 Any public repo can call these workflows directly. A full CI setup is a handful
@@ -41,7 +49,7 @@ which writes and maintains these files automatically from `holocron.config.json`
 | `stale.yml` | daily schedule | marks stale issues/PRs |
 | `post-release.yml` | `workflow_call` | dispatches `sync-broadcast.yml` with `steps=readme`; opt-in for repos that release packages other repos depend on via registry-doc |
 | `sync-broadcast.yml` | `workflow_dispatch` | discovers all repos with `sync.yml` via GitHub API and fans out a dispatch |
-| `sync-github.yml` | push to main/alpha in `holocron` | re-generates and PRs these files |
+| `sync-github.yml` | push to main in `holocron` | regenerates these files from `@theholocron/astromech` and opens a PR |
 | `sync.yml` | `workflow_call` | runs `holocron sync` with optional `--steps`, auto-commits, opens PR |
 | `test.yml` | push + PR | vitest + Codecov; optional Storybook, Chromatic, Cypress, Playwright jobs |
 | `typecheck.yml` | push + PR | `pnpm typecheck` (`tsc --noEmit`) |
@@ -144,8 +152,8 @@ The workflow and action files in this repo are **generated** from
 [theholocron/holocron](https://github.com/theholocron/holocron) — do not edit them
 directly here. To update a workflow:
 
-1. Edit `packages/cli/src/templates/workflows/<name>.yml` in `holocron`
-2. Push to `alpha` — the `sync-github` CI workflow opens a PR here automatically
+1. Edit the `.yml` in `packages/astromech/src/templates/reusable/` in `holocron`
+2. Push to `main` — the `sync-github` CI workflow opens a PR here automatically
 
 Community health files (`CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, issue templates,
 `CODEOWNERS`, `labeler.yml`, etc.) are hand-maintained in this repo directly.


### PR DESCRIPTION
The reusable workflows, composite actions and workflow-templates here are now
generated from `packages/astromech/src/templates/` in
[`theholocron/holocron`](https://github.com/theholocron/holocron) (was
`packages/cli/src/templates/index.ts`) and pushed by `holocron sync-github` —
see theholocron/holocron#587.

- README: a 'pure sync target' callout up top; `sync-github.yml` row + the
  'Source of truth' steps repointed.
- AGENTS.md: the four generated-file rows in the source-of-truth table, the
  header example, and the 'how to update' steps repointed to
  `packages/astromech/src/templates/reusable/`.

Docs-only; the generated workflow files themselves get their new header on the
next `holocron sync-github` run.

Refs: theholocron/holocron#587