### PR TITLE
docs: 📝 add the holocron composite action to the registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,11 +102,12 @@ When adding a new third-party action:
 
 ## Composite actions (`.github/actions/`)
 
-Four actions exist. All are generated; edit the templates in `holocron` to change them.
+Five actions exist. All are generated; edit the templates in `holocron` to change them.
 
 | Action | Purpose | Call |
 |---|---|---|
 | `auto-commit` | Commit + push file changes to a branch; outputs `changes-detected` | `theholocron/.github/.github/actions/auto-commit@main` |
+| `holocron` | Run a Holocron CLI task (`holocron run <task> [job]`); builds the CLI from source first when it resolves to an unbuilt workspace checkout | `theholocron/.github/.github/actions/holocron@main` |
 | `install` | `pnpm install --frozen-lockfile` | `theholocron/.github/.github/actions/install@main` |
 | `setup` | Runs `setup-node` + `install` | `theholocron/.github/.github/actions/setup@main` |
 | `setup-node` | pnpm + Node 22 + pnpm cache | `theholocron/.github/.github/actions/setup-node@main` |

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Reusable action steps callable from any workflow:
 | Action | Purpose |
 |---|---|
 | `auto-commit` | Commit + push file changes to a branch; outputs `changes-detected` |
+| `holocron` | Run a Holocron CLI task (`holocron run <task> [job]`) — the `typecheck` / `test` / `audit` workflows use it so CI runs the same command as `holocron ci` locally |
 | `install` | `pnpm install --frozen-lockfile` |
 | `setup` | Orchestrates `setup-node` + `install` in one step |
 | `setup-node` | pnpm + Node 22 with pnpm dependency caching |


### PR DESCRIPTION
Phase 8 of theholocron/holocron#589 adds a `holocron` composite action — the `typecheck` / `test` / `audit` reusable workflows call it to run `holocron run <task> [job]`, so CI executes the same command a contributor runs locally.

The action file itself (`.github/actions/holocron/action.yml`) lands via the next `holocron sync-github` run. This PR just keeps the hand-maintained `README.md` / `AGENTS.md` action tables in sync.

Refs: theholocron/holocron#589