### PR TITLE
fix: 🐛 rename yamllint.config.yml to .yamllint.yml in lint and review workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,10 +26,10 @@ on: # yamllint disable-line rule:truthy
         default: prettier.config.ts
       yaml-config:
         description: >
-          Filename for the yamllint config. Defaults to yamllint.config.yml.
+          Filename for the yamllint config. Defaults to .yamllint.yml.
         type: string
         required: false
-        default: yamllint.config.yml
+        default: .yamllint.yml
       enable-auto-commit:
         description: >
           Auto-commit super-linter fixes as a verified commit via a GitHub App.

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -74,13 +74,13 @@ jobs:
           gitleaks_flags: --log-opts=${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
 
       - name: YamlLint
-        if: ${{ hashFiles('yamllint.config.yml') != '' }}
+        if: ${{ hashFiles('.yamllint.yml') != '' }}
         uses: reviewdog/action-yamllint@b5f7217d8c815ae374d1d55840d5e569d82f01f0 # v1
         with:
           reporter: github-pr-annotations
           tool_name: "Review / yamllint"
           fail_level: error
-          yamllint_flags: -c ${{ github.workspace }}/yamllint.config.yml ${{ github.workspace }}
+          yamllint_flags: -c ${{ github.workspace }}/.yamllint.yml ${{ github.workspace }}
 
       - name: ActionLint (GitHub Actions)
         if: ${{ hashFiles('.github/workflows/*.yml', '.github/workflows/*.yaml') != '' }}


### PR DESCRIPTION
## Summary

- Updates `yaml-config` input default in `lint.yml` from `yamllint.config.yml` → `.yamllint.yml`
- Updates `hashFiles` check and `yamllint_flags` path in `review.yml` to match

## Context

Part of the yamllint rename across all repos — `.yamllint.yml` is the conventional name yamllint auto-detects locally. Companion PRs: theholocron/holocron#670 (template + astromech source), theholocron/skills#97 (skills repo fix).