### PR TITLE
fix: 🐛 rename yamllint.config.yml to .yamllint.yml for auto-detection

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,6 +1,9 @@
 ---
-
 extends: default
+
+ignore-from-file:
+  - .gitignore
+  - .yamlignore
 
 rules:
   comments:


### PR DESCRIPTION
Renames yamllint.config.yml to .yamllint.yml so yamllint auto-detects it locally. Adds ignore-from-file: [.gitignore, .yamlignore] to exclude gitignored paths. Part of org-wide migration — companion PRs in theholocron/holocron#670 and theholocron/.github#220.